### PR TITLE
CoreML loader: prefer .mlmodelc, fallback to .mlpackage/.mlmodel

### DIFF
--- a/ios/KataGo iOS/KataGo iOS/ModelPickerView.swift
+++ b/ios/KataGo iOS/KataGo iOS/ModelPickerView.swift
@@ -24,6 +24,8 @@ struct ModelPickerView: View {
     @State private var selectedModelID: UUID?
     @State private var downloaders: [UUID: Downloader?] = [:]
     @State private var isDownloaded: [UUID: Bool] = [:]
+    
+    @Binding var isHumanSLEnabled: Bool
 
     // Final selected model
     @Binding var selectedModel: NeuralNetworkModel?
@@ -42,20 +44,18 @@ struct ModelPickerView: View {
 
     var listView: some View {
         List(NeuralNetworkModel.allCases, selection: $selectedModelID) { model in
-            if model.visible {
-                VStack(alignment: .leading) {
-                    Text(model.title)
-                        .bold()
-                    Text(model.description)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.vertical)
-                .onChange(of: downloaders[model.id]??.isDownloading) { oldValue, newValue in
-                    if oldValue == true && newValue == false {
-                        if FileManager.default.fileExists(atPath: downloaders[model.id]??.destinationURL.path ?? "") {
-                            isDownloaded[model.id] = true
-                        }
+            VStack(alignment: .leading) {
+                Text(model.title)
+                    .bold()
+                Text(model.description)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical)
+            .onChange(of: downloaders[model.id]??.isDownloading) { oldValue, newValue in
+                if oldValue == true && newValue == false {
+                    if FileManager.default.fileExists(atPath: downloaders[model.id]??.destinationURL.path ?? "") {
+                        isDownloaded[model.id] = true
                     }
                 }
             }
@@ -67,6 +67,18 @@ struct ModelPickerView: View {
             if let currentSelectedModel {
                 if isDownloaded[currentSelectedModel.id] ?? false {
                     HStack {
+                        Button {
+                            isHumanSLEnabled.toggle()
+                        } label: {
+                            VStack(spacing: 4) {
+                                Image(systemName: isHumanSLEnabled ? "checkmark.square.fill" : "square")
+                                    .font(.title3)
+                                Text("Human SL")
+                                    .font(.caption)
+                            }
+                        }
+                        .padding(.horizontal)
+
                         Button {
                             selectedModel = currentSelectedModel
                         } label: {

--- a/ios/KataGo iOS/KataGo iOS/ModelRunnerView.swift
+++ b/ios/KataGo iOS/KataGo iOS/ModelRunnerView.swift
@@ -11,13 +11,15 @@ import KataGoInterface
 struct ModelRunnerView: View {
     @State private var selectedModel: NeuralNetworkModel? = nil
     @State private var katagoThread: Thread?
+    @State private var humanSLEnabled: Bool = true
 
     var body: some View {
         Group {
             if let selectedModel {
                 ContentView(selectedModel: selectedModel)
             } else {
-                ModelPickerView(selectedModel: $selectedModel)
+               ModelPickerView(isHumanSLEnabled: $humanSLEnabled,
+                               selectedModel: $selectedModel)
             }
         }
         .onChange(of: selectedModel) { _, _ in
@@ -25,13 +27,15 @@ struct ModelRunnerView: View {
                 if selectedModel.builtIn {
                     // Start KataGo with the built-in model
                     startKataGoThread(coremlModelPath: selectedModel.url,
-                                      humanCoremlModelPath: selectedModel.humanUrl,
-                                      nnLen: selectedModel.nnLen)
+                                      humanCoremlModelPath: humanSLEnabled ? selectedModel.humanUrl : nil,
+                                      nnLen: selectedModel.nnLen,
+                                      humanSLEnabled: humanSLEnabled)
                 } else {
                     if let downloadedURL = selectedModel.downloadedURL {
                         startKataGoThread(modelPath: downloadedURL.path(),
                                           useMetal: !selectedModel.builtIn,
-                                          nnLen: selectedModel.nnLen)
+                                          nnLen: selectedModel.nnLen,
+                                          humanSLEnabled: humanSLEnabled)
                     } else {
                         // Failed to get model URL, go back to the model picker view
                         self.selectedModel = nil
@@ -45,14 +49,16 @@ struct ModelRunnerView: View {
                                    useMetal: Bool = false,
                                    coremlModelPath: String? = nil,
                                    humanCoremlModelPath: String? = nil,
-                                   nnLen: Int) {
+                                   nnLen: Int,
+                                   humanSLEnabled: Bool = false) {
         // Start a thread to run KataGo GTP
         let katagoThread = Thread {
             KataGoHelper.runGtp(modelPath: modelPath,
                                 useMetal: useMetal,
                                 coremlModelPath: coremlModelPath,
                                 humanCoremlModelPath: humanCoremlModelPath,
-                                nnLen: nnLen)
+                                nnLen: nnLen,
+                                humanSLEnabled: humanSLEnabled)
 
             Task {
                 await MainActor.run {

--- a/ios/KataGo iOS/KataGoInterface/KataGoHelper.swift
+++ b/ios/KataGo iOS/KataGoInterface/KataGoHelper.swift
@@ -21,7 +21,8 @@ public class KataGoHelper {
                              useMetal: Bool = false,
                              coremlModelPath: String? = nil,
                              humanCoremlModelPath: String? = nil,
-                             nnLen: Int) {
+                             nnLen: Int, 
+                             humanSLEnabled: Bool = false) {
         let mainBundle = Bundle.main
         let modelName = "default_model"
         let modelExt = "bin.gz"
@@ -31,11 +32,11 @@ public class KataGoHelper {
         
         let humanModelName = "b18c384nbt-humanv0"
         let humanModelExt = "bin.gz"
-        
-        let humanModelPath = mainBundle.path(forResource: humanModelName,
-                                             ofType: humanModelExt)
 
-        let configName = "default_gtp"
+        let humanModelPath = humanSLEnabled ? mainBundle.path(forResource: humanModelName,
+                                             ofType: humanModelExt) : nil
+
+        let configName = humanSLEnabled ? "default_human_gtp" : "default_gtp"
         let configExt = "cfg"
 
         let configPath = mainBundle.path(forResource: configName,

--- a/ios/KataGo iOS/Resources/default_human_gtp.cfg
+++ b/ios/KataGo iOS/Resources/default_human_gtp.cfg
@@ -68,11 +68,11 @@ logToStderr = false
 
 # Configure the maximum length of analysis printed out by lz-analyze and other places.
 # Controls the number of moves after the first move in a variation.
-# analysisPVLen = 15
+analysisPVLen = 1
 
 # Report winrates for chat and analysis as (BLACK|WHITE|SIDETOMOVE).
 # Default is SIDETOMOVE, which is what tools that use LZ probably also expect
-# reportAnalysisWinratesAs = SIDETOMOVE
+reportAnalysisWinratesAs = WHITE
 
 # Larger values will make KataGo explore the top move(s) less deeply and accurately,
 # but explore and give evaluations to a greater variety of moves, for analysis (does NOT affect play).
@@ -125,9 +125,9 @@ rules = tromp-taylor
 
 # Resignation occurs if for at least resignConsecTurns in a row,
 # the winLossUtility (which is on a [-1,1] scale) is below resignThreshold.
-allowResignation = true
-resignThreshold = -0.99
-resignConsecTurns = 6
+allowResignation = false
+resignThreshold = -0.90
+resignConsecTurns = 3
 # Uncomment to make katago not resign close games, behind by fewer than this many points
 # resignMinScoreDifference = 10
 
@@ -159,7 +159,7 @@ resignConsecTurns = 6
 # Uncommenting one of these will enforce that the FIXED playoutDoublingAdvantage will only apply when KataGo plays the specified color
 # and will be negated when playing the opposite color.
 # playoutDoublingAdvantagePla = BLACK
-# playoutDoublingAdvantagePla = WHITE
+playoutDoublingAdvantagePla = WHITE
 
 # Passing and cleanup -------------
 
@@ -202,11 +202,11 @@ resignConsecTurns = 6
 # faster than the specified max if GTP tells it that it is playing under a clock as well in the current game.
 
 # If provided, limit maximum number of root visits per search to this much. (With tree reuse, visits do count earlier search)
-maxVisits = 500
+# maxVisits = 500
 # If provided, limit maximum number of new playouts per search to this much. (With tree reuse, playouts do not count earlier search)
 # maxPlayouts = 300
 # If provided, cap search time at this many seconds.
-# maxTime = 10
+maxTime = 0.1
 
 # Ponder on the opponent's turn?
 ponderingEnabled = false
@@ -217,14 +217,19 @@ maxTimePondering = 60  # Maximum time to ponder, in seconds. Comment out to make
 lagBuffer = 1.0
 
 # Number of threads to use in search
-numSearchThreads = 32
+numSearchThreads = 2
 
 # Play a little faster if the opponent is passing, for friendliness
-searchFactorAfterOnePass = 0.50
-searchFactorAfterTwoPass = 0.25
+searchFactorAfterOnePass = 1.00
+searchFactorAfterTwoPass = 1.00
 # Play a little faster if super-winning, for friendliness
-searchFactorWhenWinning = 0.40
-searchFactorWhenWinningThreshold = 0.95
+searchFactorWhenWinning = 1.00
+searchFactorWhenWinningThreshold = 1.00
+
+# Prevent KataGo from adjusting the board size based on GTP commands, ensuring it consistently
+# uses the maximum neural network size for efficiency and performance during evaluations. This
+# helps avoid potential delays associated with loading different models for varying board sizes.
+# gtpForceMaxNNSize = false
 
 # GPU Settings-------------------------------------------------------------------------------
 
@@ -232,7 +237,7 @@ searchFactorWhenWinningThreshold = 0.95
 # The default value here is roughly equal to numSearchThreads, but you can specify it manually
 # if you are running out of memory, or if you are using multiple GPUs that expect to split
 # up the work.
-nnMaxBatchSize = 16
+nnMaxBatchSize = 1
 
 # Cache up to (2 ** this) many neural net evaluations in case of transpositions in the tree.
 # Uncomment and edit to change if you want to adjust a major component of KataGo's RAM usage.
@@ -249,8 +254,8 @@ nnMaxBatchSize = 16
 # TO USE MULTIPLE GPUS:
 # Metal + CoreML backends hack here.
 # Metal backend runs the default GPU 0.
-# CoreML backend runs at the other thread.
-# So, if you want to use Metal + CoreML, you should set numNNServerThreadsPerModel to 2.
+# CoreML backend runs at another two threads.
+# So, if you want to use Metal + CoreML, you should set numNNServerThreadsPerModel to 3.
 numNNServerThreadsPerModel = 1
 
 
@@ -342,6 +347,7 @@ numNNServerThreadsPerModel = 1
 # These only apply when using the CoreML version of KataGo.
 
 # IF USING ONE MODEL:
+# coremlDeviceToUse = 0 # GPU
 coremlDeviceToUse = 100 # Neural Engine
 
 # IF USING TWO MODEL: Uncomment these two lines
@@ -380,7 +386,7 @@ coremlDeviceToUse = 100 # Neural Engine
 # chosenMovePrune = 1
 
 # Number of symmetries to sample (WITHOUT replacement) and average at the root
-# rootNumSymmetriesToSample = 1
+rootNumSymmetriesToSample = 2
 
 # Using LCB for move selection?
 # useLcbForSelection = true
@@ -487,6 +493,81 @@ coremlDeviceToUse = 100 # Neural Engine
 # avoidSgf2PatternAllowedNames = ...
 # avoidSgf2PatternMinTurnNumber = ...
 
+# ===========================================================================
+# HUMAN SL PARAMETERS
+# ===========================================================================
 
+# The most important parameter for human-like play configuration!
+# Choose the "profile" of players that the human SL model will imitate.
+# Available options are:
+# preaz_{RANK from 20k to 9d} - imitate player of given rank, before AlphaZero opening style became popular
+# rank_{RANK from 20k to 9d} - imitate player of given rank, after human openings changed due to AlphaZero.
+# proyear_{YEAR from 1800 to 2023} - imitate historical pros or insei from given year.
+humanSLProfile = rank_9d
 
+# The probability that we should play a HUMAN-like move, rather than playing KataGo's move.
+# Applies BEFORE temperature.
+humanSLChosenMoveProp = 1.0
 
+# If true, ignore the human SL model's choice of when to pass, and still use KataGo to determine that.
+# The human SL model, in theory, is not guaranteed to be reliable at when to pass for all profiles,
+# since e.g. some historical games omit passes.
+humanSLChosenMoveIgnorePass = true
+
+# By default humanSLChosenMovePiklLambda is a large number which effectively disables it.
+# Setting it to a smaller number will "suppress" human-like moves that KataGo disapproves of.
+# In particular, if set to, for example, 0.4 when KataGo judges a human SL move to lose 0.4 utility,
+# it will substantially suppress the chance of playing that move (in particular, by a factor of exp(1)).
+# Less-bad moves will also be suppressed, but not by as much, e.g. a move losing 0.2 would get lowered
+# by a factor of exp(0.5).
+# As configured lower down, utilities by default range from -1.0 (loss) to +1.0 (win), plus up to +/- 0.3 for score.
+# WARNING: ONLY moves that KataGo actually searches will get suppressed! If a move is so bad that KataGo
+# rejects it without searching it, it will NOT get suppressed.
+# Therefore, to use humanSLChosenMovePiklLambda, it is STRONGLY recommended that you also use something
+# like humanSLRootExploreProbWeightless to ensure most human moves including bad moves get searched,
+# and ALSO use at least hundreds and ideally thousands of maxVisits, to ensure enough visits.
+humanSLChosenMovePiklLambda = 100000000
+
+# These parameters tell KataGo to use the human SL policy for exploration during search.
+# Each of these specifies the probability that KataGo will perform PUCT using the Human SL policy to
+# explore different moves, rather than using KataGo's normal policy, after a certain minimal number of visits.
+# "Root": applies only at the root of the search
+# "Pla": applies during non-root nodes of the search where it is katago's turn.
+# "Opp": applies during non-root nodes of the search where it is the opponent's turn.
+# "Weightless": search the move to evaluate it, but do NOT allow this visit to affect the parent's average utility.
+# "Weightful": search the move to evaluate it, and DO allow this visit to affect the parent's average utility.
+# For example, humanSLRootExploreProbWeightless = 0.5 would tell KataGo at the root of the search to spend
+# 50% of its visits to judge different possible human moves, but NOT to use those visits for determining the
+# value of the position (avoiding biasing the utility if some human SL moves are very bad).
+# If you don't understand these well, ask for help or look up some online explainers for MCTS (Monte-Carlo Tree Search).
+humanSLRootExploreProbWeightless = 0.0
+humanSLRootExploreProbWeightful = 0.0
+humanSLPlaExploreProbWeightless = 0.0
+humanSLPlaExploreProbWeightful = 0.0
+humanSLOppExploreProbWeightless = 0.0
+humanSLOppExploreProbWeightful = 0.0
+
+# When using the human SL policy for exploration during search, use this cPUCT.
+# This only has an effect if at least one of humanSL{Root,Pla,Opp}ExploreProbWeight{less,ful} is nonzero.
+humanSLCpuctExploration = 0.50
+
+# Same as humanSLCpuctExploration, but NEVER diminshes its exploration no matter how many visits are used.
+# Normally, PUCT will sharpen with visits and spend a diminishing proportion of visits on moves with lower utility.
+# This is the coefficient for a term that does NOT diminish, i.e. if this is 0.2, then roughly moves within
+# 0.2 utility (about 10% winrate) of the best move will forever continue getting a decent fraction of visits,
+# smoothly falling off for greater utility differences.
+# Note that in combination with Weightful exploration above, if used for Opp exploration, this could be used
+# to model an opponent that will always have some chance to make small mistakes no matter how deep they search.
+# If further this was increased to a very large value, it would model an opponent that always played according
+# to the human SL raw policy. These might be interesting to experiment with for handicap play.
+humanSLCpuctPermanent = 2.0
+
+# ===========================================================================
+# PARAMETERS CHANGED FROM DEFAULT TO MAKE SURE HUMAN SL USAGE WORKS WELL
+# ===========================================================================
+
+# Make sure to take into account the recent moves in the game, don't ignore history.
+# This will produce the best imitation/prediction, since humans definitely do play differently based on where the
+# most recent moves in the game were, rather than coming fresh to the board position on every turn.
+ignorePreRootHistory = false
+analysisIgnorePreRootHistory = false


### PR DESCRIPTION
Load existing .mlmodelc directly; otherwise compile .mlpackage or raw .mlmodel.
I'm not sure why but xcode just compiles .mlpackage to .mlmodelc during build for me.