### PR TITLE
Update the cmake modules to fix cmake-macos job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
         ./katago runownershiptests gtp.cfg model.bin.gz
   
   cmake-macos:
-    runs-on: macos-15-intel
+    runs-on: macos-13
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -95,7 +95,7 @@ jobs:
     - name: Setup Xcode
       run: |
         xcode-select -p
-        sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+        sudo xcode-select -s /Applications/Xcode_15.0.1.app/Contents/Developer
 
     - name: Build KataGo with Eigen backend
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
         ./katago runownershiptests gtp.cfg model.bin.gz
   
   cmake-macos:
-    runs-on: macos-15
+    runs-on: macos-14
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
         mv CMakeLists.txt-macos CMakeLists.txt
         mkdir -p build
         cd build
-        cmake -G Ninja ../
+        cmake -G Ninja ../ -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
         ninja
 
     - name: Setup configuration

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
         ./katago runownershiptests gtp.cfg model.bin.gz
   
   cmake-macos:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
         mv CMakeLists.txt-macos CMakeLists.txt
         mkdir -p build
         cd build
-        cmake -G Ninja ../ -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
+        cmake -G Ninja ../
         ninja
 
     - name: Setup configuration

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,7 @@ jobs:
       run: |
         mkdir -p cpp/build
         cd cpp/build
+        cmake --version
         cmake -G Ninja -DUSE_BACKEND=EIGEN ../
         ninja
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,16 @@ jobs:
         xcode-select -p
         sudo xcode-select -s /Applications/Xcode_15.0.1.app/Contents/Developer
 
+    - name: Verify cmake
+      run: |
+        which cmake
+        cmake --version
+        brew uninstall cmake
+        brew untap local/pinned
+        brew install cmake
+        which cmake
+        cmake --version
+
     - name: Build KataGo with Eigen backend
       run: |
         mkdir -p cpp/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
         ./katago runownershiptests gtp.cfg model.bin.gz
   
   cmake-macos:
-    runs-on: macos-15-intel
+    runs-on: macos-14
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
         ./katago runownershiptests gtp.cfg model.bin.gz
   
   cmake-macos:
-    runs-on: macos-14
+    runs-on: macos-15-intel
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,16 +97,6 @@ jobs:
         xcode-select -p
         sudo xcode-select -s /Applications/Xcode_15.0.1.app/Contents/Developer
 
-    - name: Verify cmake
-      run: |
-        which cmake
-        cmake --version
-        brew uninstall cmake
-        brew untap local/pinned
-        brew install cmake
-        which cmake
-        cmake --version
-
     - name: Build KataGo with Eigen backend
       run: |
         mkdir -p cpp/build

--- a/cpp/CMakeLists.txt-macos
+++ b/cpp/CMakeLists.txt-macos
@@ -92,20 +92,18 @@ endif()
 
 #--------------------------- C++ Swift Interop --------------------------------
 
-_swift_generate_cxx_header_target(
-  KataGoSwift_Swift_h
+add_library(KataGoSwift STATIC
+  neuralnet/coremlbackend.swift
+  neuralnet/coremlmodel.swift
+  neuralnet/metalbackend.swift)
+
+_swift_generate_cxx_header(
   KataGoSwift
   "${CMAKE_CURRENT_BINARY_DIR}/include/KataGoSwift/KataGoSwift-swift.h"
   SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/neuralnet/coremlbackend.swift"
   "${CMAKE_CURRENT_SOURCE_DIR}/neuralnet/coremlmodel.swift"
   "${CMAKE_CURRENT_SOURCE_DIR}/neuralnet/metalbackend.swift")
 
-add_library(KataGoSwift STATIC
-  neuralnet/coremlbackend.swift
-  neuralnet/coremlmodel.swift
-  neuralnet/metalbackend.swift)
-
-add_dependencies(KataGoSwift KataGoSwift_Swift_h)
 target_include_directories(KataGoSwift PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/include")
 set_target_properties(KataGoSwift PROPERTIES Swift_MODULE_NAME "KataGoSwift")
 target_compile_options(KataGoSwift PUBLIC

--- a/cpp/macos/cmake/modules/AddSwift.cmake
+++ b/cpp/macos/cmake/modules/AddSwift.cmake
@@ -5,46 +5,74 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 
-include(CheckCompilerFlag)
 
-# Generate bridging header from Swift to C++
-# NOTE: This logic will eventually be upstreamed into CMake
-function(_swift_generate_cxx_header_target target module header)
-  cmake_parse_arguments(ARG "" "" "SOURCES;SEARCH_PATHS;DEPENDS" ${ARGN})
-  if(NOT ARG_SOURCES)
-    message(FATAL_ERROR "No sources provided to 'swift_generate_cxx_header_target'")
+# Generate the bridging header from Swift to C++
+#
+# target: the name of the target to generate headers for.
+#         This target must build swift source files.
+# header: the name of the header file to generate.
+#
+# NOTE: This logic will eventually be unstreamed into CMake.
+function(_swift_generate_cxx_header target header)
+  if(NOT TARGET ${target})
+    message(FATAL_ERROR "Target ${target} not defined.")
+  endif()
+
+  if(NOT DEFINED CMAKE_Swift_COMPILER)
+    message(WARNING "Swift not enabled in project. Cannot generate headers for Swift files.")
+    return()
+  endif()
+
+  cmake_parse_arguments(ARG "" "" "SEARCH_PATHS;MODULE_NAME" ${ARGN})
+
+  if(NOT ARG_MODULE_NAME)
+    set(target_module_name $<TARGET_PROPERTY:${target},Swift_MODULE_NAME>)
+    set(ARG_MODULE_NAME $<IF:$<BOOL:${target_module_name}>,${target_module_name},${target}>)
   endif()
 
   if(ARG_SEARCH_PATHS)
     list(TRANSFORM ARG_SEARCH_PATHS PREPEND "-I")
-    string(REPLACE ";" " " EXPANDED_SEARCH_PATHS "${ARG_SEARCH_PATHS}")
   endif()
 
-  if(APPLE)
+  if(APPLE AND CMAKE_OSX_SYSROOT)
     set(SDK_FLAGS "-sdk" "${CMAKE_OSX_SYSROOT}")
   elseif(WIN32)
     set(SDK_FLAGS "-sdk" "$ENV{SDKROOT}")
+  elseif(CMAKE_SYSROOT)
+    set(SDK_FLAGS "-sdk" "${CMAKE_SYSROOT}")
   endif()
 
-  add_custom_command(
-    OUTPUT
-      "${header}"
-    COMMAND
-      ${CMAKE_Swift_COMPILER} -frontend -typecheck
-      ${EXPANDED_SEARCH_PATHS}
-      ${ARG_SOURCES}
-      ${SDK_FLAGS}
-      -module-name "${module}"
-      -cxx-interoperability-mode=default
-      -emit-clang-header-path "${header}"
-    DEPENDS
-      ${ARG_DEPENDS}
-    COMMENT
-      "Generating '${header}'"
-  )
+  cmake_path(APPEND CMAKE_CURRENT_BINARY_DIR include
+    OUTPUT_VARIABLE base_path)
 
-  add_custom_target("${target}"
-    DEPENDS
-      "${header}"
-  )
+  cmake_path(APPEND base_path ${header}
+    OUTPUT_VARIABLE header_path)
+
+  cmake_path(APPEND CMAKE_CURRENT_BINARY_DIR "${ARG_MODULE_NAME}.emit-module.d" OUTPUT_VARIABLE depfile_path)
+
+  set(_AllSources $<PATH:ABSOLUTE_PATH,$<TARGET_PROPERTY:${target},SOURCES>,${CMAKE_CURRENT_SOURCE_DIR}>)
+  set(_SwiftSources $<FILTER:${_AllSources},INCLUDE,\\.swift$>)
+  add_custom_command(OUTPUT ${header_path}
+    DEPENDS ${_SwiftSources}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND
+      ${CMAKE_Swift_COMPILER} -typecheck
+      ${ARG_SEARCH_PATHS}
+      ${_SwiftSources}
+      ${SDK_FLAGS}
+      -module-name "${ARG_MODULE_NAME}"
+      -cxx-interoperability-mode=default
+      -emit-clang-header-path ${header_path}
+      -emit-dependencies
+    DEPFILE "${depfile_path}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT
+      "Generating '${header_path}'"
+    COMMAND_EXPAND_LISTS)
+
+  # Added to public interface for dependees to find.
+  target_include_directories(${target} PUBLIC ${base_path})
+  # Added to the target to ensure target rebuilds if header changes and is used
+  # by sources in the target.
+  target_sources(${target} PRIVATE ${header_path})
 endfunction()

--- a/cpp/macos/cmake/modules/InitializeSwift.cmake
+++ b/cpp/macos/cmake/modules/InitializeSwift.cmake
@@ -26,7 +26,7 @@ endfunction()
 function(_setup_swift_paths)
   # If we haven't set the swift library search paths, do that now
   if(NOT SWIFT_LIBRARY_SEARCH_PATHS)
-    if(APPLE)
+    if(CMAKE_OSX_SYSROOT)
       set(SDK_FLAGS "-sdk" "${CMAKE_OSX_SYSROOT}")
     endif()
 


### PR DESCRIPTION
### Summary

GitHub Actions recently upgraded `cmake` to version `4.*` https://github.com/actions/runner-images/issues/12934, which caused the `cmake-macos` CI job to fail.

### Changes

* Updated our `cmake` modules to match the latest source code from [swift-cmake-examples](https://github.com/swiftlang/swift-cmake-examples).
* Verified that the updated configuration resolves the build failure on macOS.

### Result

The `cmake-macos` job now completes successfully with `cmake 4.*`.