### PR TITLE
Fix ONNX include to use onnx_pb.h for proper ONNX_API macro definition

### DIFF
--- a/cpp/neuralnet/onnxmodelbuilder.cpp
+++ b/cpp/neuralnet/onnxmodelbuilder.cpp
@@ -6,7 +6,7 @@
 #include "../neuralnet/activations.h"
 #include "../core/global.h"
 
-#include <onnx/onnx-ml.pb.h>
+#include <onnx/onnx_pb.h>
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
## Summary
- Replace `#include <onnx/onnx-ml.pb.h>` with `#include <onnx/onnx_pb.h>` in `onnxmodelbuilder.cpp`
- `onnx_pb.h` defines the `ONNX_API` macro before including `onnx-ml.pb.h`, fixing "variable has initializer but incomplete type" errors on Linux/GCC

## Test plan
- [x] Build with cmake + GCC on Linux
- [x] Run `runonnxtests.sh` (tiny net, GPU error, canary eval tests)

https://claude.ai/code/session_01QoHzJ3riCeRwyvk6ntSzXT