### PR TITLE
Add tune-params (QRS-Tune) for cpuctExploration and match statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ cpp/tests/results/matchsgfs2/games.sgfs
 
 cpp/data/
 versions/
-build/
 cpp/build
 cpp/out
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *~
 __pycache__
 *.h5
+build/
 *.log
 *.cbp
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 *~
 __pycache__
 *.h5
-build/
 *.log
 *.cbp
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ cpp/tests/results/matchsgfs2/games.sgfs
 
 cpp/data/
 versions/
+build/
 cpp/build
 cpp/out
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ Run a high-performance match engine that will play a pool of bots against each o
 
    * `./katago match -config <MATCH_CONFIG>.cfg -log-file match.log -sgf-output-dir <DIR TO WRITE THE SGFS>`
 
+Tune PUCT search hyperparameters via QRS-Tune sequential optimization:
+
+   * `./katago tune-params -config <TUNE_CONFIG>.cfg`
+
 Force OpenCL tuner to re-tune:
 
    * `./katago tuner -config <GTP_CONFIG>.cfg`

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -307,6 +307,7 @@ add_executable(katago
   tests/tinymodel.cpp
   tests/tinymodeldata.cpp
   distributed/client.cpp
+  qrstune/QRSOptimizer.cpp
   command/commandline.cpp
   command/analysis.cpp
   command/benchmark.cpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -318,6 +318,7 @@ add_executable(katago
   command/gputest.cpp
   command/gtp.cpp
   command/match.cpp
+  command/tuneparams.cpp
   command/misc.cpp
   command/runtests.cpp
   command/sandbox.cpp

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -35,7 +35,7 @@ Summary of source folders, in approximate dependency order, from lowest level to
 * `distributed` - Code for talking to https webserver for volunteers to contribute distributed self-play games for training.
 * `tests` - A variety of tests.
   * `models` - A directory with a small number of small-sized (and not very strong) models for running tests.
-* `qrstune` - Header-only QRS-Tune (Quadratic Regression Sequential) optimizer for hyperparameter tuning.
+* `qrstune` - QRS-Tune (Quadratic Response Surface) optimizer for hyperparameter tuning.
 * `command` - Top-level subcommands callable by users. GTP, analysis commands, benchmarking, selfplay data generation, etc.
   * `commandline.{cpp,h}` - Common command line logic shared by all subcommands.
   * `gtp.cpp` - Main GTP engine.

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -35,6 +35,7 @@ Summary of source folders, in approximate dependency order, from lowest level to
 * `distributed` - Code for talking to https webserver for volunteers to contribute distributed self-play games for training.
 * `tests` - A variety of tests.
   * `models` - A directory with a small number of small-sized (and not very strong) models for running tests.
+* `qrstune` - Header-only QRS-Tune (Quadratic Regression Sequential) optimizer for hyperparameter tuning.
 * `command` - Top-level subcommands callable by users. GTP, analysis commands, benchmarking, selfplay data generation, etc.
   * `commandline.{cpp,h}` - Common command line logic shared by all subcommands.
   * `gtp.cpp` - Main GTP engine.
@@ -44,6 +45,7 @@ Summary of source folders, in approximate dependency order, from lowest level to
   * `selfplay.cpp` - Selfplay data generation engine.
   * `gatekeeper.cpp` - Gating engine to filter neural nets for selfplay data generation.
   * `match.cpp` - Match engine for testing different parameters that can use huge batch sizes to efficiently play games in parallel.
+  * `tuneparams.cpp` - Tune PUCT search hyperparameters via QRS-Tune sequential optimization.
 
 Other folders:
 

--- a/cpp/command/match.cpp
+++ b/cpp/command/match.cpp
@@ -1,4 +1,6 @@
 #include "../core/global.h"
+#include "../core/elo.h"
+#include "../core/fancymath.h"
 #include "../core/fileutils.h"
 #include "../core/makedir.h"
 #include "../core/config_parser.h"
@@ -12,7 +14,6 @@
 #include "../main.h"
 
 #include <array>
-#include <cmath>
 #include <csignal>
 
 using namespace std;
@@ -26,126 +27,6 @@ static void signalHandler(int signal)
     sigReceived.store(true);
     shouldStop.store(true);
   }
-}
-
-//Match statistics helpers
-
-//Wilson score 95% two-tailed confidence interval (draws counted as 0.5 wins)
-static void wilsonCI95(double wins, double n, double& lo, double& hi) {
-  const double z = 1.96;
-  double p = wins / n;
-  double denom = 1.0 + z*z/n;
-  double center = (p + z*z/(2*n)) / denom;
-  double margin = z * sqrt(p*(1-p)/n + z*z/(4*n*n)) / denom;
-  lo = center - margin;
-  hi = center + margin;
-}
-
-//One-tailed p-value: P(experiment winrate <= 0.5 | data), using normal approximation
-static double oneTailedPValue(double wins, double n) {
-  if(n <= 0) return 0.5;
-  double z = (wins - 0.5*n) / (0.5*sqrt(n));
-  return 0.5 * erfc(z / sqrt(2.0));
-}
-
-//Bradley-Terry MLE Elo (global, all-bot ranking)
-//pairStats: {nameA,nameB} -> {winsA, winsB, draws}  nameA < nameB lexicographically
-static bool computeBradleyTerryElo(
-  const vector<string>& botNames,
-  const map<pair<string,string>, array<int64_t,3>>& pairStats,
-  vector<double>& outElo,
-  vector<double>& outStderr
-) {
-  int N = (int)botNames.size();
-  const double eloPerStrength = 400.0 * log10(exp(1.0)); //~173.7
-
-  map<string,int> nameIdx;
-  for(int i = 0; i < N; i++) nameIdx[botNames[i]] = i;
-
-  //w[i][j] = effective wins of i vs j (draws count 0.5)
-  vector<vector<double>> w(N, vector<double>(N, 0.0));
-  for(auto& kv : pairStats) {
-    auto itA = nameIdx.find(kv.first.first);
-    auto itB = nameIdx.find(kv.first.second);
-    if(itA == nameIdx.end() || itB == nameIdx.end()) continue;
-    int a = itA->second, b = itB->second;
-    w[a][b] += kv.second[0] + 0.5 * kv.second[2];
-    w[b][a] += kv.second[1] + 0.5 * kv.second[2];
-  }
-
-  //theta[0] = 0 (reference, first bot), optimize theta[1..N-1]
-  vector<double> theta(N, 0.0);
-  int M = N - 1;
-
-  bool converged = (M == 0);
-  if(M > 0) {
-    for(int iter = 0; iter < 200; iter++) {
-      vector<double> grad(M, 0.0);
-      vector<vector<double>> H(M, vector<double>(M, 0.0));
-      for(int i = 0; i < N; i++) {
-        for(int j = i+1; j < N; j++) {
-          double nij = w[i][j] + w[j][i];
-          if(nij <= 0.0) continue;
-          double sigma = 1.0 / (1.0 + exp(theta[j] - theta[i]));
-          double fish = nij * sigma * (1.0 - sigma);
-          double gij = w[i][j] - nij * sigma;
-          if(i > 0) { grad[i-1] += gij; H[i-1][i-1] -= fish; }
-          if(j > 0) { grad[j-1] -= gij; H[j-1][j-1] -= fish; }
-          if(i > 0 && j > 0) { H[i-1][j-1] += fish; H[j-1][i-1] += fish; }
-        }
-      }
-      //Solve H*delta = -grad via Gaussian elimination
-      vector<vector<double>> aug(M, vector<double>(M+1, 0.0));
-      for(int r = 0; r < M; r++) {
-        for(int c = 0; c < M; c++) aug[r][c] = H[r][c];
-        aug[r][M] = -grad[r];
-      }
-      for(int col = 0; col < M; col++) {
-        int piv = col;
-        for(int r = col+1; r < M; r++)
-          if(fabs(aug[r][col]) > fabs(aug[piv][col])) piv = r;
-        swap(aug[col], aug[piv]);
-        if(fabs(aug[col][col]) < 1e-12) continue;
-        double inv = 1.0 / aug[col][col];
-        for(int r = col+1; r < M; r++) {
-          double f = aug[r][col] * inv;
-          for(int c = col; c <= M; c++) aug[r][c] -= f * aug[col][c];
-        }
-      }
-      vector<double> delta(M, 0.0);
-      for(int r = M-1; r >= 0; r--) {
-        double s = aug[r][M];
-        for(int c = r+1; c < M; c++) s -= aug[r][c] * delta[c];
-        if(fabs(aug[r][r]) > 1e-12) delta[r] = s / aug[r][r];
-      }
-      double maxDelta = 0.0;
-      for(int r = 0; r < M; r++) {
-        theta[r+1] += delta[r];
-        maxDelta = max(maxDelta, fabs(delta[r]));
-      }
-      if(maxDelta < 1e-6) { converged = true; break; }
-    }
-  }
-
-  //Convert log-strength to Elo relative to bot 0
-  outElo.resize(N);
-  outStderr.resize(N, 0.0);
-  for(int i = 0; i < N; i++)
-    outElo[i] = (theta[i] - theta[0]) * eloPerStrength;
-
-  //Fisher information diagonal -> stderr
-  for(int i = 1; i < N; i++) {
-    double fish = 0.0;
-    for(int j = 0; j < N; j++) {
-      if(j == i) continue;
-      double nij = w[i][j] + w[j][i];
-      if(nij <= 0.0) continue;
-      double sigma = 1.0 / (1.0 + exp(theta[j] - theta[i]));
-      fish += nij * sigma * (1.0 - sigma);
-    }
-    if(fish > 0.0) outStderr[i] = eloPerStrength / sqrt(fish);
-  }
-  return converged;
 }
 
 int MainCmds::match(const vector<string>& args) {
@@ -496,7 +377,7 @@ int MainCmds::match(const vector<string>& args) {
     }
 
     vector<double> elo, eloStderr;
-    bool eloConverged = computeBradleyTerryElo(activeBots, pairStats, elo, eloStderr);
+    bool eloConverged = ComputeElos::computeBradleyTerryElo(activeBots, pairStats, elo, eloStderr);
 
     logger.write("");
     if(!eloConverged)
@@ -518,8 +399,8 @@ int MainCmds::match(const vector<string>& args) {
       if(total == 0) continue;
       double wins = wA + 0.5 * d;
       double lo, hi;
-      wilsonCI95(wins, (double)total, lo, hi);
-      double pval = oneTailedPValue(wins, (double)total);
+      FancyMath::wilsonCI95(wins, (double)total, lo, hi);
+      double pval = FancyMath::oneTailedPValue(wins, (double)total);
       string sig = (pval < 0.05) ? " *" : "";
       logger.write(
         "  " + kv.first.first + " vs " + kv.first.second +

--- a/cpp/command/match.cpp
+++ b/cpp/command/match.cpp
@@ -50,7 +50,7 @@ static double oneTailedPValue(double wins, double n) {
 
 //Bradley-Terry MLE Elo (global, all-bot ranking)
 //pairStats: {nameA,nameB} -> {winsA, winsB, draws}  nameA < nameB lexicographically
-static void computeBradleyTerryElo(
+static bool computeBradleyTerryElo(
   const vector<string>& botNames,
   const map<pair<string,string>, array<int64_t,3>>& pairStats,
   vector<double>& outElo,
@@ -77,6 +77,7 @@ static void computeBradleyTerryElo(
   vector<double> theta(N, 0.0);
   int M = N - 1;
 
+  bool converged = (M == 0);
   if(M > 0) {
     for(int iter = 0; iter < 200; iter++) {
       vector<double> grad(M, 0.0);
@@ -122,7 +123,7 @@ static void computeBradleyTerryElo(
         theta[r+1] += delta[r];
         maxDelta = max(maxDelta, fabs(delta[r]));
       }
-      if(maxDelta < 1e-6) break;
+      if(maxDelta < 1e-6) { converged = true; break; }
     }
   }
 
@@ -144,6 +145,7 @@ static void computeBradleyTerryElo(
     }
     if(fish > 0.0) outStderr[i] = eloPerStrength / sqrt(fish);
   }
+  return converged;
 }
 
 int MainCmds::match(const vector<string>& args) {
@@ -494,9 +496,11 @@ int MainCmds::match(const vector<string>& args) {
     }
 
     vector<double> elo, eloStderr;
-    computeBradleyTerryElo(activeBots, pairStats, elo, eloStderr);
+    bool eloConverged = computeBradleyTerryElo(activeBots, pairStats, elo, eloStderr);
 
     logger.write("");
+    if(!eloConverged)
+      logger.write("Warning: Bradley-Terry Elo estimation did not fully converge");
     logger.write("=== match Results ===");
     logger.write("Global Elo (Bradley-Terry MLE, reference=" + activeBots[0] + "):");
     for(int i = 0; i < (int)activeBots.size(); i++) {

--- a/cpp/command/match.cpp
+++ b/cpp/command/match.cpp
@@ -11,6 +11,8 @@
 #include "../command/commandline.h"
 #include "../main.h"
 
+#include <array>
+#include <cmath>
 #include <csignal>
 
 using namespace std;
@@ -23,6 +25,124 @@ static void signalHandler(int signal)
   if(signal == SIGINT || signal == SIGTERM) {
     sigReceived.store(true);
     shouldStop.store(true);
+  }
+}
+
+// ===== Match statistics helpers =====
+
+// Wilson score 95% two-tailed confidence interval (draws counted as 0.5 wins)
+static void wilsonCI95(double wins, double n, double& lo, double& hi) {
+  const double z = 1.96;
+  double p = wins / n;
+  double denom = 1.0 + z*z/n;
+  double center = (p + z*z/(2*n)) / denom;
+  double margin = z * sqrt(p*(1-p)/n + z*z/(4*n*n)) / denom;
+  lo = center - margin;
+  hi = center + margin;
+}
+
+// One-tailed p-value: P(experiment winrate <= 0.5 | data), using normal approximation
+static double oneTailedPValue(double wins, double n) {
+  if(n <= 0) return 0.5;
+  double z = (wins - 0.5*n) / (0.5*sqrt(n));
+  return 0.5 * erfc(z / sqrt(2.0));
+}
+
+// Bradley-Terry MLE Elo (global, all-bot ranking)
+// pairStats: {nameA,nameB} -> {winsA, winsB, draws}  nameA < nameB lexicographically
+static void computeBradleyTerryElo(
+  const vector<string>& botNames,
+  const map<pair<string,string>, array<int64_t,3>>& pairStats,
+  vector<double>& outElo,
+  vector<double>& outStderr
+) {
+  int N = (int)botNames.size();
+  const double ELO_PER_STRENGTH = 400.0 * log10(exp(1.0)); // ~173.7
+
+  map<string,int> nameIdx;
+  for(int i = 0; i < N; i++) nameIdx[botNames[i]] = i;
+
+  // w[i][j] = effective wins of i vs j (draws count 0.5)
+  vector<vector<double>> w(N, vector<double>(N, 0.0));
+  for(auto& kv : pairStats) {
+    auto itA = nameIdx.find(kv.first.first);
+    auto itB = nameIdx.find(kv.first.second);
+    if(itA == nameIdx.end() || itB == nameIdx.end()) continue;
+    int a = itA->second, b = itB->second;
+    w[a][b] += kv.second[0] + 0.5 * kv.second[2];
+    w[b][a] += kv.second[1] + 0.5 * kv.second[2];
+  }
+
+  // theta[0] = 0 (reference, first bot), optimize theta[1..N-1]
+  vector<double> theta(N, 0.0);
+  int M = N - 1;
+
+  if(M > 0) {
+    for(int iter = 0; iter < 200; iter++) {
+      vector<double> grad(M, 0.0);
+      vector<vector<double>> H(M, vector<double>(M, 0.0));
+      for(int i = 0; i < N; i++) {
+        for(int j = i+1; j < N; j++) {
+          double nij = w[i][j] + w[j][i];
+          if(nij <= 0.0) continue;
+          double sigma = 1.0 / (1.0 + exp(theta[j] - theta[i]));
+          double fish = nij * sigma * (1.0 - sigma);
+          double gij = w[i][j] - nij * sigma;
+          if(i > 0) { grad[i-1] += gij; H[i-1][i-1] -= fish; }
+          if(j > 0) { grad[j-1] -= gij; H[j-1][j-1] -= fish; }
+          if(i > 0 && j > 0) { H[i-1][j-1] += fish; H[j-1][i-1] += fish; }
+        }
+      }
+      // Solve H*delta = -grad via Gaussian elimination
+      vector<vector<double>> aug(M, vector<double>(M+1, 0.0));
+      for(int r = 0; r < M; r++) {
+        for(int c = 0; c < M; c++) aug[r][c] = H[r][c];
+        aug[r][M] = -grad[r];
+      }
+      for(int col = 0; col < M; col++) {
+        int piv = col;
+        for(int r = col+1; r < M; r++)
+          if(fabs(aug[r][col]) > fabs(aug[piv][col])) piv = r;
+        swap(aug[col], aug[piv]);
+        if(fabs(aug[col][col]) < 1e-12) continue;
+        double inv = 1.0 / aug[col][col];
+        for(int r = col+1; r < M; r++) {
+          double f = aug[r][col] * inv;
+          for(int c = col; c <= M; c++) aug[r][c] -= f * aug[col][c];
+        }
+      }
+      vector<double> delta(M, 0.0);
+      for(int r = M-1; r >= 0; r--) {
+        double s = aug[r][M];
+        for(int c = r+1; c < M; c++) s -= aug[r][c] * delta[c];
+        if(fabs(aug[r][r]) > 1e-12) delta[r] = s / aug[r][r];
+      }
+      double maxDelta = 0.0;
+      for(int r = 0; r < M; r++) {
+        theta[r+1] += delta[r];
+        maxDelta = max(maxDelta, fabs(delta[r]));
+      }
+      if(maxDelta < 1e-6) break;
+    }
+  }
+
+  // Convert log-strength to Elo relative to bot 0
+  outElo.resize(N);
+  outStderr.resize(N, 0.0);
+  for(int i = 0; i < N; i++)
+    outElo[i] = (theta[i] - theta[0]) * ELO_PER_STRENGTH;
+
+  // Fisher information diagonal -> stderr
+  for(int i = 1; i < N; i++) {
+    double fish = 0.0;
+    for(int j = 0; j < N; j++) {
+      if(j == i) continue;
+      double nij = w[i][j] + w[j][i];
+      if(nij <= 0.0) continue;
+      double sigma = 1.0 / (1.0 + exp(theta[j] - theta[i]));
+      fish += nij * sigma * (1.0 - sigma);
+    }
+    if(fish > 0.0) outStderr[i] = ELO_PER_STRENGTH / sqrt(fish);
   }
 }
 
@@ -250,10 +370,13 @@ int MainCmds::match(const vector<string>& args) {
   int64_t gameCount = 0;
   std::map<string,double> timeUsedByBotMap;
   std::map<string,double> movesByBotMap;
+  map<pair<string,string>, array<int64_t,3>> pairStats;
+  // key: {nameA, nameB} with nameA < nameB lexicographically
+  // value: {winsA, winsB, draws}
 
   auto runMatchLoop = [
     &gameRunner,&matchPairer,&sgfOutputDir,&logger,&gameSeedBase,&patternBonusTables,
-    &statsMutex, &gameCount, &timeUsedByBotMap, &movesByBotMap
+    &statsMutex, &gameCount, &timeUsedByBotMap, &movesByBotMap, &pairStats
   ](
     uint64_t threadHash
   ) {
@@ -303,6 +426,20 @@ int MainCmds::match(const vector<string>& args) {
           movesByBotMap[gameData->bName] += (double)gameData->bMoveCount;
           movesByBotMap[gameData->wName] += (double)gameData->wMoveCount;
 
+          // Update pairwise W/L/D stats
+          {
+            const string& bName = gameData->bName;
+            const string& wName = gameData->wName;
+            Player winner = gameData->endHist.winner;
+            bool aIsBlack = (bName < wName);
+            const string& nameA = aIsBlack ? bName : wName;
+            const string& nameB = aIsBlack ? wName : bName;
+            auto& ps = pairStats[{nameA, nameB}];
+            if(winner == P_BLACK)      { if(aIsBlack) ps[0]++; else ps[1]++; }
+            else if(winner == P_WHITE) { if(aIsBlack) ps[1]++; else ps[0]++; }
+            else                       { ps[2]++; }
+          }
+
           int64_t x = gameCount;
           while(x % 2 == 0 && x > 1) x /= 2;
           if(x == 1 || x == 3 || x == 5) {
@@ -343,6 +480,56 @@ int MainCmds::match(const vector<string>& args) {
   }
   for(int i = 0; i<threads.size(); i++)
     threads[i].join();
+
+  // ===== Final match statistics =====
+  if(!pairStats.empty()) {
+    vector<string> activeBots;
+    {
+      set<string> seen;
+      for(auto& kv : pairStats) {
+        seen.insert(kv.first.first);
+        seen.insert(kv.first.second);
+      }
+      activeBots.assign(seen.begin(), seen.end());
+    }
+
+    vector<double> elo, eloStderr;
+    computeBradleyTerryElo(activeBots, pairStats, elo, eloStderr);
+
+    logger.write("");
+    logger.write("=== match Results ===");
+    logger.write("Global Elo (Bradley-Terry MLE, reference=" + activeBots[0] + "):");
+    for(int i = 0; i < (int)activeBots.size(); i++) {
+      string sign = (elo[i] >= 0) ? "+" : "";
+      string line = "  " + activeBots[i] + " : " +
+        sign + Global::strprintf("%.1f", elo[i]) + " +/- " + Global::strprintf("%.1f", eloStderr[i]);
+      if(i == 0) line += "  (reference)";
+      logger.write(line);
+    }
+    logger.write("");
+    logger.write("Pairwise summary:");
+    for(auto& kv : pairStats) {
+      int64_t wA = kv.second[0], wB = kv.second[1], d = kv.second[2];
+      int64_t total = wA + wB + d;
+      if(total == 0) continue;
+      double wins = wA + 0.5 * d;
+      double lo, hi;
+      wilsonCI95(wins, (double)total, lo, hi);
+      double pval = oneTailedPValue(wins, (double)total);
+      string sig = (pval < 0.05) ? " *" : "";
+      logger.write(
+        "  " + kv.first.first + " vs " + kv.first.second +
+        " : Games=" + Global::int64ToString(total) +
+        " W=" + Global::int64ToString(wA) +
+        " L=" + Global::int64ToString(wB) +
+        " D=" + Global::int64ToString(d) +
+        " | " + kv.first.first + " winrate=" + Global::strprintf("%.3f", wins/total) +
+        " [95% CI: " + Global::strprintf("%.3f", lo) + ", " + Global::strprintf("%.3f", hi) + "]" +
+        " | p=" + Global::strprintf("%.4f", pval) + sig
+      );
+    }
+    logger.write("");
+  }
 
   delete matchPairer;
   delete gameRunner;

--- a/cpp/command/match.cpp
+++ b/cpp/command/match.cpp
@@ -28,9 +28,9 @@ static void signalHandler(int signal)
   }
 }
 
-// ===== Match statistics helpers =====
+//Match statistics helpers
 
-// Wilson score 95% two-tailed confidence interval (draws counted as 0.5 wins)
+//Wilson score 95% two-tailed confidence interval (draws counted as 0.5 wins)
 static void wilsonCI95(double wins, double n, double& lo, double& hi) {
   const double z = 1.96;
   double p = wins / n;
@@ -41,15 +41,15 @@ static void wilsonCI95(double wins, double n, double& lo, double& hi) {
   hi = center + margin;
 }
 
-// One-tailed p-value: P(experiment winrate <= 0.5 | data), using normal approximation
+//One-tailed p-value: P(experiment winrate <= 0.5 | data), using normal approximation
 static double oneTailedPValue(double wins, double n) {
   if(n <= 0) return 0.5;
   double z = (wins - 0.5*n) / (0.5*sqrt(n));
   return 0.5 * erfc(z / sqrt(2.0));
 }
 
-// Bradley-Terry MLE Elo (global, all-bot ranking)
-// pairStats: {nameA,nameB} -> {winsA, winsB, draws}  nameA < nameB lexicographically
+//Bradley-Terry MLE Elo (global, all-bot ranking)
+//pairStats: {nameA,nameB} -> {winsA, winsB, draws}  nameA < nameB lexicographically
 static void computeBradleyTerryElo(
   const vector<string>& botNames,
   const map<pair<string,string>, array<int64_t,3>>& pairStats,
@@ -57,12 +57,12 @@ static void computeBradleyTerryElo(
   vector<double>& outStderr
 ) {
   int N = (int)botNames.size();
-  const double ELO_PER_STRENGTH = 400.0 * log10(exp(1.0)); // ~173.7
+  const double eloPerStrength = 400.0 * log10(exp(1.0)); //~173.7
 
   map<string,int> nameIdx;
   for(int i = 0; i < N; i++) nameIdx[botNames[i]] = i;
 
-  // w[i][j] = effective wins of i vs j (draws count 0.5)
+  //w[i][j] = effective wins of i vs j (draws count 0.5)
   vector<vector<double>> w(N, vector<double>(N, 0.0));
   for(auto& kv : pairStats) {
     auto itA = nameIdx.find(kv.first.first);
@@ -73,7 +73,7 @@ static void computeBradleyTerryElo(
     w[b][a] += kv.second[1] + 0.5 * kv.second[2];
   }
 
-  // theta[0] = 0 (reference, first bot), optimize theta[1..N-1]
+  //theta[0] = 0 (reference, first bot), optimize theta[1..N-1]
   vector<double> theta(N, 0.0);
   int M = N - 1;
 
@@ -93,7 +93,7 @@ static void computeBradleyTerryElo(
           if(i > 0 && j > 0) { H[i-1][j-1] += fish; H[j-1][i-1] += fish; }
         }
       }
-      // Solve H*delta = -grad via Gaussian elimination
+      //Solve H*delta = -grad via Gaussian elimination
       vector<vector<double>> aug(M, vector<double>(M+1, 0.0));
       for(int r = 0; r < M; r++) {
         for(int c = 0; c < M; c++) aug[r][c] = H[r][c];
@@ -126,13 +126,13 @@ static void computeBradleyTerryElo(
     }
   }
 
-  // Convert log-strength to Elo relative to bot 0
+  //Convert log-strength to Elo relative to bot 0
   outElo.resize(N);
   outStderr.resize(N, 0.0);
   for(int i = 0; i < N; i++)
-    outElo[i] = (theta[i] - theta[0]) * ELO_PER_STRENGTH;
+    outElo[i] = (theta[i] - theta[0]) * eloPerStrength;
 
-  // Fisher information diagonal -> stderr
+  //Fisher information diagonal -> stderr
   for(int i = 1; i < N; i++) {
     double fish = 0.0;
     for(int j = 0; j < N; j++) {
@@ -142,7 +142,7 @@ static void computeBradleyTerryElo(
       double sigma = 1.0 / (1.0 + exp(theta[j] - theta[i]));
       fish += nij * sigma * (1.0 - sigma);
     }
-    if(fish > 0.0) outStderr[i] = ELO_PER_STRENGTH / sqrt(fish);
+    if(fish > 0.0) outStderr[i] = eloPerStrength / sqrt(fish);
   }
 }
 
@@ -371,8 +371,8 @@ int MainCmds::match(const vector<string>& args) {
   std::map<string,double> timeUsedByBotMap;
   std::map<string,double> movesByBotMap;
   map<pair<string,string>, array<int64_t,3>> pairStats;
-  // key: {nameA, nameB} with nameA < nameB lexicographically
-  // value: {winsA, winsB, draws}
+  //key: {nameA, nameB} with nameA < nameB lexicographically
+  //value: {winsA, winsB, draws}
 
   auto runMatchLoop = [
     &gameRunner,&matchPairer,&sgfOutputDir,&logger,&gameSeedBase,&patternBonusTables,
@@ -426,7 +426,7 @@ int MainCmds::match(const vector<string>& args) {
           movesByBotMap[gameData->bName] += (double)gameData->bMoveCount;
           movesByBotMap[gameData->wName] += (double)gameData->wMoveCount;
 
-          // Update pairwise W/L/D stats
+          //Update pairwise W/L/D stats
           {
             const string& bName = gameData->bName;
             const string& wName = gameData->wName;
@@ -481,7 +481,7 @@ int MainCmds::match(const vector<string>& args) {
   for(int i = 0; i<threads.size(); i++)
     threads[i].join();
 
-  // ===== Final match statistics =====
+  //Final match statistics
   if(!pairStats.empty()) {
     vector<string> activeBots;
     {

--- a/cpp/command/runtests.cpp
+++ b/cpp/command/runtests.cpp
@@ -5,6 +5,7 @@
 #include "../core/rand.h"
 #include "../core/elo.h"
 #include "../core/fancymath.h"
+#include "../qrstune/QRSOptimizer.h"
 #include "../core/config_parser.h"
 #include "../core/datetime.h"
 #include "../core/fileutils.h"
@@ -35,6 +36,7 @@ int MainCmds::runtests(const vector<string>& args) {
   DateTime::runTests();
   FancyMath::runTests();
   ComputeElos::runTests();
+  QRSTune::runTests();
   Base64::runTests();
   ThreadTest::runTests();
 

--- a/cpp/command/tuneparams.cpp
+++ b/cpp/command/tuneparams.cpp
@@ -18,8 +18,19 @@
 
 #include <vector>
 #include <algorithm>
+#include <csignal>
 
 using namespace std;
+
+static std::atomic<bool> sigReceived(false);
+static std::atomic<bool> shouldStop(false);
+static void signalHandler(int signal)
+{
+  if(signal == SIGINT || signal == SIGTERM) {
+    sigReceived.store(true);
+    shouldStop.store(true);
+  }
+}
 
 //Number of dimensions = number of PUCT params being tuned
 static const int nDims = 3;
@@ -218,6 +229,12 @@ int MainCmds::tuneparams(const vector<string>& args) {
   );
   logger.write("Loaded neural nets");
 
+  //Signal handling for graceful shutdown
+  if(!std::atomic_is_lock_free(&shouldStop))
+    throw StringError("shouldStop is not lock free, signal-quitting mechanism for terminating will NOT work!");
+  std::signal(SIGINT, signalHandler);
+  std::signal(SIGTERM, signalHandler);
+
   //QRS-Tune setup
   uint64_t qrsSeed = seedRand.nextUInt64();
   QRSTune::QRSTuner tuner(nDims, qrsSeed, numTrials);
@@ -263,7 +280,7 @@ int MainCmds::tuneparams(const vector<string>& args) {
     }
 
     string seed = gameSeedBase + ":" + Global::intToString(trial);
-    auto shouldStopFunc = []() noexcept { return false; };
+    auto shouldStopFunc = []() noexcept { return shouldStop.load(); };
 
     FinishedGameData* gameData = gameRunner->runGame(
       seed, botSpecB, botSpecW,
@@ -296,6 +313,9 @@ int MainCmds::tuneparams(const vector<string>& args) {
     }
 
     tuner.addResult(sample, outcome);
+
+    if(shouldStop.load())
+      break;
 
     //Progress report every 100 trials
     if((trial + 1) % 100 == 0) {

--- a/cpp/command/tuneparams.cpp
+++ b/cpp/command/tuneparams.cpp
@@ -22,12 +22,10 @@
 
 using namespace std;
 
-static std::atomic<bool> sigReceived(false);
 static std::atomic<bool> shouldStop(false);
 static void signalHandler(int signal)
 {
   if(signal == SIGINT || signal == SIGTERM) {
-    sigReceived.store(true);
     shouldStop.store(true);
   }
 }

--- a/cpp/command/tuneparams.cpp
+++ b/cpp/command/tuneparams.cpp
@@ -1,0 +1,353 @@
+// command/tuneparams.cpp
+// KataGo hyperparameter tuning via QRS-Tune sequential optimization.
+// Runs two bots (base reference vs experiment) for numTrials games,
+// adapting experiment bot's PUCT parameters toward higher win rates.
+
+#include "../core/global.h"
+#include "../core/config_parser.h"
+#include "../core/logger.h"
+#include "../core/rand.h"
+#include "../search/searchparams.h"
+#include "../program/setup.h"
+#include "../program/play.h"
+#include "../program/playsettings.h"
+#include "../command/commandline.h"
+#include "../main.h"
+
+#include "../qrstune/QRSOptimizer.h"
+
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+// Number of dimensions = number of PUCT params being tuned
+static const int NDIMS = 3;
+
+static const char* PARAM_NAMES[NDIMS] = {
+  "cpuctExploration",
+  "cpuctExplorationLog",
+  "cpuctUtilityStdevPrior"
+};
+
+// Default search ranges (used when config keys are absent)
+static const double QRS_DEFAULT_MINS[NDIMS] = {0.5,  0.05, 0.1};
+static const double QRS_DEFAULT_MAXS[NDIMS] = {2.0,  1.0,  0.8};
+
+// Config keys for per-dimension search ranges
+static const char* RANGE_MIN_KEYS[NDIMS] = {
+  "cpuctExplorationMin", "cpuctExplorationLogMin", "cpuctUtilityStdevPriorMin"
+};
+static const char* RANGE_MAX_KEYS[NDIMS] = {
+  "cpuctExplorationMax", "cpuctExplorationLogMax", "cpuctUtilityStdevPriorMax"
+};
+
+// Map QRS-Tune normalized coordinate x in [-1,+1] to real PUCT value.
+static double qrsDimToReal(int dim, double x, const double* mins, const double* maxs) {
+  double center = (mins[dim] + maxs[dim]) * 0.5;
+  double radius = (maxs[dim] - mins[dim]) * 0.5;
+  return center + x * radius;
+}
+
+static void qrsToPUCT(
+  const vector<double>& x,
+  double& cpuctExploration,
+  double& cpuctExplorationLog,
+  double& cpuctUtilityStdevPrior,
+  const double* mins, const double* maxs
+) {
+  cpuctExploration       = qrsDimToReal(0, x[0], mins, maxs);
+  cpuctExplorationLog    = qrsDimToReal(1, x[1], mins, maxs);
+  cpuctUtilityStdevPrior = qrsDimToReal(2, x[2], mins, maxs);
+}
+
+// Print ASCII-art regression curve for each PUCT dimension.
+// For dimension d: fix all other dims at vBest, sweep d from -1 to +1.
+static void printRegressionCurves(const QRSTune::QRSTuner& tuner,
+                                   const vector<double>& vBest,
+                                   const double* mins, const double* maxs,
+                                   Logger& logger) {
+  const int PLOT_W = 60;
+  const int PLOT_H = 20;
+
+  for(int dim = 0; dim < NDIMS; dim++) {
+    vector<string> canvas(PLOT_H, string(PLOT_W, ' '));
+
+    int bestCol = (int)((vBest[dim] + 1.0) / 2.0 * (PLOT_W - 1) + 0.5);
+    bestCol = max(0, min(PLOT_W - 1, bestCol));
+
+    vector<double> xSlice(vBest);
+    for(int col = 0; col < PLOT_W; col++) {
+      double t = -1.0 + 2.0 * col / (PLOT_W - 1);
+      xSlice[dim] = t;
+      double winRate = tuner.model().predict(xSlice.data());
+
+      int row = (int)((1.0 - winRate) * (PLOT_H - 1) + 0.5);
+      row = max(0, min(PLOT_H - 1, row));
+      canvas[row][col] = (col == bestCol) ? '*' : 'o';
+    }
+
+    double bestReal    = qrsDimToReal(dim, vBest[dim], mins, maxs);
+    double bestWinRate = tuner.model().predict(vBest.data());
+    logger.write("");
+    logger.write(
+      "[Dim " + Global::intToString(dim) + "] " + PARAM_NAMES[dim] +
+      "  (best QRS=" + Global::strprintf("%.3f", vBest[dim]) +
+      " -> real=" + Global::strprintf("%.3f", bestReal) +
+      ", est.winrate=" + Global::strprintf("%.3f", bestWinRate) + ")"
+    );
+
+    for(int row = 0; row < PLOT_H; row++) {
+      string label;
+      if(row == 0)               label = "1.0 |";
+      else if(row == PLOT_H / 2) label = "0.5 |";
+      else if(row == PLOT_H - 1) label = "0.0 |";
+      else                       label = "    |";
+      logger.write(label + canvas[row]);
+    }
+    logger.write("    +" + string(PLOT_W, '-'));
+
+    {
+      string line(PLOT_W + 5, ' ');
+      const int OFF = 5;
+      auto place = [&](int col, const string& lbl) {
+        int pos = OFF + col - (int)lbl.size() / 2;
+        if(pos < 0) pos = 0;
+        for(int i = 0; i < (int)lbl.size() && pos + i < (int)line.size(); i++)
+          line[pos + i] = lbl[i];
+      };
+      place(0,          Global::strprintf("%.3f", qrsDimToReal(dim, -1.0, mins, maxs)));
+      place(PLOT_W / 2, Global::strprintf("%.3f", qrsDimToReal(dim,  0.0, mins, maxs)));
+      place(PLOT_W - 1, Global::strprintf("%.3f", qrsDimToReal(dim, +1.0, mins, maxs)));
+      size_t last = line.find_last_not_of(' ');
+      logger.write(line.substr(0, last + 1));
+    }
+  }
+  logger.write("");
+}
+
+int MainCmds::tuneparams(const vector<string>& args) {
+  Board::initHash();
+  ScoreValue::initTables();
+  Rand seedRand;
+
+  ConfigParser cfg;
+  string logFile;
+  try {
+    KataGoCommandLine cmd(
+      "Tune KataGo hyperparameters using sequential optimization (QRS-Tune).\n"
+      "Runs numTrials games between a fixed reference bot (bot0) and an\n"
+      "experiment bot (bot1) whose PUCT parameters are adapted each trial."
+    );
+    cmd.addConfigFileArg("", "tune_params.cfg");
+
+    TCLAP::ValueArg<string> logFileArg("", "log-file", "Log file to output to", false, string(), "FILE");
+    cmd.add(logFileArg);
+    cmd.setShortUsageArgLimit();
+    cmd.addOverrideConfigArg();
+
+    cmd.parseArgs(args);
+    logFile = logFileArg.getValue();
+    cmd.getConfig(cfg);
+  }
+  catch(TCLAP::ArgException& e) {
+    cerr << "Error: " << e.error() << " for argument " << e.argId() << endl;
+    return 1;
+  }
+
+  Logger logger(&cfg);
+  logger.addFile(logFile);
+  logger.write("tune-params starting...");
+  logger.write(string("Git revision: ") + Version::getGitRevision());
+
+  // --- Read tuning-specific config ---
+  int numTrials = cfg.getInt("numTrials", 1, 100000);
+
+  // --- Search ranges (configurable; defaults preserve prior behaviour) ---
+  double qrsMins[NDIMS], qrsMaxs[NDIMS];
+  for(int d = 0; d < NDIMS; d++) {
+    qrsMins[d] = cfg.contains(RANGE_MIN_KEYS[d])
+                    ? cfg.getDouble(RANGE_MIN_KEYS[d], -1e9, 1e9)
+                    : QRS_DEFAULT_MINS[d];
+    qrsMaxs[d] = cfg.contains(RANGE_MAX_KEYS[d])
+                    ? cfg.getDouble(RANGE_MAX_KEYS[d], -1e9, 1e9)
+                    : QRS_DEFAULT_MAXS[d];
+    if(qrsMins[d] >= qrsMaxs[d])
+      throw StringError(
+        string("tune-params: ") + RANGE_MIN_KEYS[d] + " must be < " + RANGE_MAX_KEYS[d]);
+  }
+  logger.write(
+    "QRS ranges: cpuctExploration=[" +
+    Global::strprintf("%.4f", qrsMins[0]) + "," + Global::strprintf("%.4f", qrsMaxs[0]) +
+    "] cpuctExplorationLog=[" +
+    Global::strprintf("%.4f", qrsMins[1]) + "," + Global::strprintf("%.4f", qrsMaxs[1]) +
+    "] cpuctUtilityStdevPrior=[" +
+    Global::strprintf("%.4f", qrsMins[2]) + "," + Global::strprintf("%.4f", qrsMaxs[2]) + "]"
+  );
+
+  // --- Load search params for both bots ---
+  vector<SearchParams> paramss = Setup::loadParams(cfg, Setup::SETUP_FOR_MATCH);
+  if((int)paramss.size() < 2)
+    throw StringError("tune-params: config must define numBots = 2 (bot0 = reference, bot1 = experiment)");
+
+  // --- Model files ---
+  string nnModelFile0 = cfg.getString("nnModelFile0");
+  string nnModelFile1 = cfg.getString("nnModelFile1");
+  vector<string> nnModelFiles = {nnModelFile0, nnModelFile1};
+
+  // --- Game runner setup ---
+  PlaySettings playSettings = PlaySettings::loadForMatch(cfg);
+  GameRunner* gameRunner = new GameRunner(cfg, playSettings, logger);
+  int maxBoardX = gameRunner->getGameInitializer()->getMaxBoardXSize();
+  int maxBoardY = gameRunner->getGameInitializer()->getMaxBoardYSize();
+
+  // --- Initialize neural net inference ---
+  Setup::initializeSession(cfg);
+  const int expectedConcurrentEvals = max(paramss[0].numThreads, paramss[1].numThreads);
+  vector<string> expectedSha256s;
+  vector<NNEvaluator*> nnEvals = Setup::initializeNNEvaluators(
+    nnModelFiles, nnModelFiles, expectedSha256s,
+    cfg, logger, seedRand,
+    expectedConcurrentEvals,
+    maxBoardX, maxBoardY,
+    /*defaultMaxBatchSize=*/-1,
+    /*defaultRequireExactNNLen=*/(maxBoardX == gameRunner->getGameInitializer()->getMinBoardXSize() &&
+                                  maxBoardY == gameRunner->getGameInitializer()->getMinBoardYSize()),
+    /*disableFP16=*/false,
+    Setup::SETUP_FOR_MATCH
+  );
+  logger.write("Loaded neural nets");
+
+  // --- QRS-Tune setup ---
+  uint64_t qrsSeed = seedRand.nextUInt64();
+  QRSTune::QRSTuner tuner(NDIMS, qrsSeed, numTrials);
+
+  const string gameSeedBase = Global::uint64ToHexString(seedRand.nextUInt64());
+
+  int wins = 0, losses = 0, draws = 0;
+
+  logger.write("Starting " + Global::intToString(numTrials) + " tuning trials");
+
+  for(int trial = 0; trial < numTrials; trial++) {
+    // Step 1: Get next sample from QRS-Tune
+    vector<double> sample = tuner.nextSample();
+
+    // Step 2: Map normalized coordinates to PUCT parameter values
+    double cpuctExploration, cpuctExplorationLog, cpuctUtilityStdevPrior;
+    qrsToPUCT(sample, cpuctExploration, cpuctExplorationLog, cpuctUtilityStdevPrior, qrsMins, qrsMaxs);
+
+    // Step 3: Build experiment bot params with updated PUCT values
+    SearchParams expParams = paramss[1];
+    expParams.cpuctExploration       = cpuctExploration;
+    expParams.cpuctExplorationLog    = cpuctExplorationLog;
+    expParams.cpuctUtilityStdevPrior = cpuctUtilityStdevPrior;
+
+    // Step 4: Alternate colors to remove first-move advantage bias
+    // Even trials: experiment bot plays Black; odd trials: experiment bot plays White
+    bool expIsBlack = (trial % 2 == 0);
+    MatchPairer::BotSpec botSpecB, botSpecW;
+    if(expIsBlack) {
+      botSpecB.botIdx     = 1;
+      botSpecB.botName    = "experiment";
+      botSpecB.nnEval     = nnEvals[1];
+      botSpecB.baseParams = expParams;
+      botSpecW.botIdx     = 0;
+      botSpecW.botName    = "base";
+      botSpecW.nnEval     = nnEvals[0];
+      botSpecW.baseParams = paramss[0];
+    } else {
+      botSpecB.botIdx     = 0;
+      botSpecB.botName    = "base";
+      botSpecB.nnEval     = nnEvals[0];
+      botSpecB.baseParams = paramss[0];
+      botSpecW.botIdx     = 1;
+      botSpecW.botName    = "experiment";
+      botSpecW.nnEval     = nnEvals[1];
+      botSpecW.baseParams = expParams;
+    }
+
+    // Step 5: Run one game
+    string seed = gameSeedBase + ":" + Global::intToString(trial);
+    auto shouldStopFunc = []() noexcept { return false; };
+
+    FinishedGameData* gameData = gameRunner->runGame(
+      seed, botSpecB, botSpecW,
+      /*forkData=*/nullptr,
+      /*startPosSample=*/nullptr,
+      logger,
+      shouldStopFunc,
+      /*shouldPause=*/nullptr,
+      /*checkForNewNNEval=*/nullptr,
+      /*afterInitialization=*/nullptr,
+      /*onEachMove=*/nullptr
+    );
+
+    // Step 6: Determine outcome for experiment bot
+    double outcome = 0.5;  // draw default
+    if(gameData != nullptr) {
+      Player winner = gameData->endHist.winner;
+      if(expIsBlack) {
+        if(winner == P_BLACK)       { outcome = 1.0; wins++; }
+        else if(winner == P_WHITE)  { outcome = 0.0; losses++; }
+        else                        { outcome = 0.5; draws++; }
+      } else {
+        if(winner == P_WHITE)       { outcome = 1.0; wins++; }
+        else if(winner == P_BLACK)  { outcome = 0.0; losses++; }
+        else                        { outcome = 0.5; draws++; }
+      }
+      delete gameData;
+    } else {
+      draws++;
+      logger.write("Warning: trial " + Global::intToString(trial) + " returned null game data");
+    }
+
+    // Step 7: Feed result to QRS-Tune (triggers periodic refit and pruning)
+    tuner.addResult(sample, outcome);
+
+    // Progress report every 100 trials
+    if((trial + 1) % 100 == 0) {
+      vector<double> vBest = tuner.bestCoords();
+      double bE, bLog, bStdev;
+      qrsToPUCT(vBest, bE, bLog, bStdev, qrsMins, qrsMaxs);
+      logger.write(
+        "Trial " + Global::intToString(trial + 1) + "/" + Global::intToString(numTrials) +
+        " | W=" + Global::intToString(wins) + " L=" + Global::intToString(losses) + " D=" + Global::intToString(draws) +
+        " | best: cpuctExploration=" + Global::doubleToString(bE) +
+        " cpuctExplorationLog=" + Global::doubleToString(bLog) +
+        " cpuctUtilityStdevPrior=" + Global::doubleToString(bStdev)
+      );
+    }
+  }
+
+  // --- Final result ---
+  vector<double> vBest = tuner.bestCoords();
+  double bestE, bestLog, bestStdev;
+  qrsToPUCT(vBest, bestE, bestLog, bestStdev, qrsMins, qrsMaxs);
+
+  logger.write("");
+  logger.write("=== tune-params Results ===");
+  logger.write(
+    "Trials: " + Global::intToString(numTrials) +
+    "  Wins: " + Global::intToString(wins) +
+    "  Losses: " + Global::intToString(losses) +
+    "  Draws: " + Global::intToString(draws)
+  );
+  logger.write("Best cpuctExploration       = " + Global::doubleToString(bestE));
+  logger.write("Best cpuctExplorationLog    = " + Global::doubleToString(bestLog));
+  logger.write("Best cpuctUtilityStdevPrior = " + Global::doubleToString(bestStdev));
+  logger.write(
+    "QRS raw coordinates: [" + Global::doubleToString(vBest[0]) + ", " +
+    Global::doubleToString(vBest[1]) + ", " + Global::doubleToString(vBest[2]) + "]"
+  );
+
+  // --- ASCII-art regression curves (one per PUCT dimension) ---
+  printRegressionCurves(tuner, vBest, qrsMins, qrsMaxs, logger);
+
+  // --- Cleanup ---
+  delete gameRunner;
+  for(NNEvaluator* eval : nnEvals)
+    delete eval;
+
+  ScoreValue::freeTables();
+  return 0;
+}

--- a/cpp/command/tuneparams.cpp
+++ b/cpp/command/tuneparams.cpp
@@ -69,6 +69,7 @@ static void printRegressionCurves(const QRSTune::QRSTuner& tuner,
                                    Logger& logger) {
   const int PLOT_W = 60;
   const int PLOT_H = 20;
+  double bestWinRate = tuner.model().predict(vBest.data());
 
   for(int dim = 0; dim < NDIMS; dim++) {
     vector<string> canvas(PLOT_H, string(PLOT_W, ' '));
@@ -87,8 +88,7 @@ static void printRegressionCurves(const QRSTune::QRSTuner& tuner,
       canvas[row][col] = (col == bestCol) ? '*' : 'o';
     }
 
-    double bestReal    = qrsDimToReal(dim, vBest[dim], mins, maxs);
-    double bestWinRate = tuner.model().predict(vBest.data());
+    double bestReal = qrsDimToReal(dim, vBest[dim], mins, maxs);
     logger.write("");
     logger.write(
       "[Dim " + Global::intToString(dim) + "] " + PARAM_NAMES[dim] +
@@ -229,21 +229,17 @@ int MainCmds::tuneparams(const vector<string>& args) {
   logger.write("Starting " + Global::intToString(numTrials) + " tuning trials");
 
   for(int trial = 0; trial < numTrials; trial++) {
-    // Step 1: Get next sample from QRS-Tune
     vector<double> sample = tuner.nextSample();
 
-    // Step 2: Map normalized coordinates to PUCT parameter values
     double cpuctExploration, cpuctExplorationLog, cpuctUtilityStdevPrior;
     qrsToPUCT(sample, cpuctExploration, cpuctExplorationLog, cpuctUtilityStdevPrior, qrsMins, qrsMaxs);
 
-    // Step 3: Build experiment bot params with updated PUCT values
     SearchParams expParams = paramss[1];
     expParams.cpuctExploration       = cpuctExploration;
     expParams.cpuctExplorationLog    = cpuctExplorationLog;
     expParams.cpuctUtilityStdevPrior = cpuctUtilityStdevPrior;
 
-    // Step 4: Alternate colors to remove first-move advantage bias
-    // Even trials: experiment bot plays Black; odd trials: experiment bot plays White
+    // Alternate colors to remove first-move advantage bias
     bool expIsBlack = (trial % 2 == 0);
     MatchPairer::BotSpec botSpecB, botSpecW;
     if(expIsBlack) {
@@ -266,7 +262,6 @@ int MainCmds::tuneparams(const vector<string>& args) {
       botSpecW.baseParams = expParams;
     }
 
-    // Step 5: Run one game
     string seed = gameSeedBase + ":" + Global::intToString(trial);
     auto shouldStopFunc = []() noexcept { return false; };
 
@@ -282,8 +277,7 @@ int MainCmds::tuneparams(const vector<string>& args) {
       /*onEachMove=*/nullptr
     );
 
-    // Step 6: Determine outcome for experiment bot
-    double outcome = 0.5;  // draw default
+    double outcome = 0.5;
     if(gameData != nullptr) {
       Player winner = gameData->endHist.winner;
       if(expIsBlack) {
@@ -301,7 +295,6 @@ int MainCmds::tuneparams(const vector<string>& args) {
       logger.write("Warning: trial " + Global::intToString(trial) + " returned null game data");
     }
 
-    // Step 7: Feed result to QRS-Tune (triggers periodic refit and pruning)
     tuner.addResult(sample, outcome);
 
     // Progress report every 100 trials
@@ -348,6 +341,7 @@ int MainCmds::tuneparams(const vector<string>& args) {
   for(NNEvaluator* eval : nnEvals)
     delete eval;
 
+  NeuralNet::globalCleanup();
   ScoreValue::freeTables();
   return 0;
 }

--- a/cpp/command/tuneparams.cpp
+++ b/cpp/command/tuneparams.cpp
@@ -1,7 +1,7 @@
-// command/tuneparams.cpp
-// KataGo hyperparameter tuning via QRS-Tune sequential optimization.
-// Runs two bots (base reference vs experiment) for numTrials games,
-// adapting experiment bot's PUCT parameters toward higher win rates.
+//command/tuneparams.cpp
+//KataGo hyperparameter tuning via QRS-Tune sequential optimization.
+//Runs two bots (base reference vs experiment) for numTrials games,
+//adapting experiment bot's PUCT parameters toward higher win rates.
 
 #include "../core/global.h"
 #include "../core/config_parser.h"
@@ -21,28 +21,28 @@
 
 using namespace std;
 
-// Number of dimensions = number of PUCT params being tuned
-static const int NDIMS = 3;
+//Number of dimensions = number of PUCT params being tuned
+static const int nDims = 3;
 
-static const char* PARAM_NAMES[NDIMS] = {
+static const char* paramNames[nDims] = {
   "cpuctExploration",
   "cpuctExplorationLog",
   "cpuctUtilityStdevPrior"
 };
 
-// Default search ranges (used when config keys are absent)
-static const double QRS_DEFAULT_MINS[NDIMS] = {0.5,  0.05, 0.1};
-static const double QRS_DEFAULT_MAXS[NDIMS] = {2.0,  1.0,  0.8};
+//Default search ranges (used when config keys are absent)
+static const double qrsDefaultMins[nDims] = {0.5,  0.05, 0.1};
+static const double qrsDefaultMaxs[nDims] = {2.0,  1.0,  0.8};
 
-// Config keys for per-dimension search ranges
-static const char* RANGE_MIN_KEYS[NDIMS] = {
+//Config keys for per-dimension search ranges
+static const char* rangeMinKeys[nDims] = {
   "cpuctExplorationMin", "cpuctExplorationLogMin", "cpuctUtilityStdevPriorMin"
 };
-static const char* RANGE_MAX_KEYS[NDIMS] = {
+static const char* rangeMaxKeys[nDims] = {
   "cpuctExplorationMax", "cpuctExplorationLogMax", "cpuctUtilityStdevPriorMax"
 };
 
-// Map QRS-Tune normalized coordinate x in [-1,+1] to real PUCT value.
+//Map QRS-Tune normalized coordinate x in [-1,+1] to real PUCT value.
 static double qrsDimToReal(int dim, double x, const double* mins, const double* maxs) {
   double center = (mins[dim] + maxs[dim]) * 0.5;
   double radius = (maxs[dim] - mins[dim]) * 0.5;
@@ -61,64 +61,64 @@ static void qrsToPUCT(
   cpuctUtilityStdevPrior = qrsDimToReal(2, x[2], mins, maxs);
 }
 
-// Print ASCII-art regression curve for each PUCT dimension.
-// For dimension d: fix all other dims at vBest, sweep d from -1 to +1.
+//Print ASCII-art regression curve for each PUCT dimension.
+//For dimension d: fix all other dims at vBest, sweep d from -1 to +1.
 static void printRegressionCurves(const QRSTune::QRSTuner& tuner,
                                    const vector<double>& vBest,
                                    const double* mins, const double* maxs,
                                    Logger& logger) {
-  const int PLOT_W = 60;
-  const int PLOT_H = 20;
+  const int plotW = 60;
+  const int plotH = 20;
   double bestWinRate = tuner.model().predict(vBest.data());
 
-  for(int dim = 0; dim < NDIMS; dim++) {
-    vector<string> canvas(PLOT_H, string(PLOT_W, ' '));
+  for(int dim = 0; dim < nDims; dim++) {
+    vector<string> canvas(plotH, string(plotW, ' '));
 
-    int bestCol = (int)((vBest[dim] + 1.0) / 2.0 * (PLOT_W - 1) + 0.5);
-    bestCol = max(0, min(PLOT_W - 1, bestCol));
+    int bestCol = (int)((vBest[dim] + 1.0) / 2.0 * (plotW - 1) + 0.5);
+    bestCol = max(0, min(plotW - 1, bestCol));
 
     vector<double> xSlice(vBest);
-    for(int col = 0; col < PLOT_W; col++) {
-      double t = -1.0 + 2.0 * col / (PLOT_W - 1);
+    for(int col = 0; col < plotW; col++) {
+      double t = -1.0 + 2.0 * col / (plotW - 1);
       xSlice[dim] = t;
       double winRate = tuner.model().predict(xSlice.data());
 
-      int row = (int)((1.0 - winRate) * (PLOT_H - 1) + 0.5);
-      row = max(0, min(PLOT_H - 1, row));
+      int row = (int)((1.0 - winRate) * (plotH - 1) + 0.5);
+      row = max(0, min(plotH - 1, row));
       canvas[row][col] = (col == bestCol) ? '*' : 'o';
     }
 
     double bestReal = qrsDimToReal(dim, vBest[dim], mins, maxs);
     logger.write("");
     logger.write(
-      "[Dim " + Global::intToString(dim) + "] " + PARAM_NAMES[dim] +
+      "[Dim " + Global::intToString(dim) + "] " + paramNames[dim] +
       "  (best QRS=" + Global::strprintf("%.3f", vBest[dim]) +
       " -> real=" + Global::strprintf("%.3f", bestReal) +
       ", est.winrate=" + Global::strprintf("%.3f", bestWinRate) + ")"
     );
 
-    for(int row = 0; row < PLOT_H; row++) {
+    for(int row = 0; row < plotH; row++) {
       string label;
       if(row == 0)               label = "1.0 |";
-      else if(row == PLOT_H / 2) label = "0.5 |";
-      else if(row == PLOT_H - 1) label = "0.0 |";
+      else if(row == plotH / 2) label = "0.5 |";
+      else if(row == plotH - 1) label = "0.0 |";
       else                       label = "    |";
       logger.write(label + canvas[row]);
     }
-    logger.write("    +" + string(PLOT_W, '-'));
+    logger.write("    +" + string(plotW, '-'));
 
     {
-      string line(PLOT_W + 5, ' ');
-      const int OFF = 5;
+      string line(plotW + 5, ' ');
+      const int off = 5;
       auto place = [&](int col, const string& lbl) {
-        int pos = OFF + col - (int)lbl.size() / 2;
+        int pos = off + col - (int)lbl.size() / 2;
         if(pos < 0) pos = 0;
         for(int i = 0; i < (int)lbl.size() && pos + i < (int)line.size(); i++)
           line[pos + i] = lbl[i];
       };
       place(0,          Global::strprintf("%.3f", qrsDimToReal(dim, -1.0, mins, maxs)));
-      place(PLOT_W / 2, Global::strprintf("%.3f", qrsDimToReal(dim,  0.0, mins, maxs)));
-      place(PLOT_W - 1, Global::strprintf("%.3f", qrsDimToReal(dim, +1.0, mins, maxs)));
+      place(plotW / 2, Global::strprintf("%.3f", qrsDimToReal(dim,  0.0, mins, maxs)));
+      place(plotW - 1, Global::strprintf("%.3f", qrsDimToReal(dim, +1.0, mins, maxs)));
       size_t last = line.find_last_not_of(' ');
       logger.write(line.substr(0, last + 1));
     }
@@ -160,21 +160,21 @@ int MainCmds::tuneparams(const vector<string>& args) {
   logger.write("tune-params starting...");
   logger.write(string("Git revision: ") + Version::getGitRevision());
 
-  // --- Read tuning-specific config ---
+  //Read tuning-specific config
   int numTrials = cfg.getInt("numTrials", 1, 100000);
 
-  // --- Search ranges (configurable; defaults preserve prior behaviour) ---
-  double qrsMins[NDIMS], qrsMaxs[NDIMS];
-  for(int d = 0; d < NDIMS; d++) {
-    qrsMins[d] = cfg.contains(RANGE_MIN_KEYS[d])
-                    ? cfg.getDouble(RANGE_MIN_KEYS[d], -1e9, 1e9)
-                    : QRS_DEFAULT_MINS[d];
-    qrsMaxs[d] = cfg.contains(RANGE_MAX_KEYS[d])
-                    ? cfg.getDouble(RANGE_MAX_KEYS[d], -1e9, 1e9)
-                    : QRS_DEFAULT_MAXS[d];
+  //Search ranges (configurable; defaults preserve prior behaviour)
+  double qrsMins[nDims], qrsMaxs[nDims];
+  for(int d = 0; d < nDims; d++) {
+    qrsMins[d] = cfg.contains(rangeMinKeys[d])
+                    ? cfg.getDouble(rangeMinKeys[d], -1e9, 1e9)
+                    : qrsDefaultMins[d];
+    qrsMaxs[d] = cfg.contains(rangeMaxKeys[d])
+                    ? cfg.getDouble(rangeMaxKeys[d], -1e9, 1e9)
+                    : qrsDefaultMaxs[d];
     if(qrsMins[d] >= qrsMaxs[d])
       throw StringError(
-        string("tune-params: ") + RANGE_MIN_KEYS[d] + " must be < " + RANGE_MAX_KEYS[d]);
+        string("tune-params: ") + rangeMinKeys[d] + " must be < " + rangeMaxKeys[d]);
   }
   logger.write(
     "QRS ranges: cpuctExploration=[" +
@@ -185,23 +185,23 @@ int MainCmds::tuneparams(const vector<string>& args) {
     Global::strprintf("%.4f", qrsMins[2]) + "," + Global::strprintf("%.4f", qrsMaxs[2]) + "]"
   );
 
-  // --- Load search params for both bots ---
+  //Load search params for both bots
   vector<SearchParams> paramss = Setup::loadParams(cfg, Setup::SETUP_FOR_MATCH);
   if((int)paramss.size() < 2)
     throw StringError("tune-params: config must define numBots = 2 (bot0 = reference, bot1 = experiment)");
 
-  // --- Model files ---
+  //Model files
   string nnModelFile0 = cfg.getString("nnModelFile0");
   string nnModelFile1 = cfg.getString("nnModelFile1");
   vector<string> nnModelFiles = {nnModelFile0, nnModelFile1};
 
-  // --- Game runner setup ---
+  //Game runner setup
   PlaySettings playSettings = PlaySettings::loadForMatch(cfg);
   GameRunner* gameRunner = new GameRunner(cfg, playSettings, logger);
   int maxBoardX = gameRunner->getGameInitializer()->getMaxBoardXSize();
   int maxBoardY = gameRunner->getGameInitializer()->getMaxBoardYSize();
 
-  // --- Initialize neural net inference ---
+  //Initialize neural net inference
   Setup::initializeSession(cfg);
   const int expectedConcurrentEvals = max(paramss[0].numThreads, paramss[1].numThreads);
   vector<string> expectedSha256s;
@@ -218,9 +218,9 @@ int MainCmds::tuneparams(const vector<string>& args) {
   );
   logger.write("Loaded neural nets");
 
-  // --- QRS-Tune setup ---
+  //QRS-Tune setup
   uint64_t qrsSeed = seedRand.nextUInt64();
-  QRSTune::QRSTuner tuner(NDIMS, qrsSeed, numTrials);
+  QRSTune::QRSTuner tuner(nDims, qrsSeed, numTrials);
 
   const string gameSeedBase = Global::uint64ToHexString(seedRand.nextUInt64());
 
@@ -239,7 +239,7 @@ int MainCmds::tuneparams(const vector<string>& args) {
     expParams.cpuctExplorationLog    = cpuctExplorationLog;
     expParams.cpuctUtilityStdevPrior = cpuctUtilityStdevPrior;
 
-    // Alternate colors to remove first-move advantage bias
+    //Alternate colors to remove first-move advantage bias
     bool expIsBlack = (trial % 2 == 0);
     MatchPairer::BotSpec botSpecB, botSpecW;
     if(expIsBlack) {
@@ -267,18 +267,18 @@ int MainCmds::tuneparams(const vector<string>& args) {
 
     FinishedGameData* gameData = gameRunner->runGame(
       seed, botSpecB, botSpecW,
-      /*forkData=*/nullptr,
-      /*startPosSample=*/nullptr,
+      /*forkData=*/NULL,
+      /*startPosSample=*/NULL,
       logger,
       shouldStopFunc,
-      /*shouldPause=*/nullptr,
-      /*checkForNewNNEval=*/nullptr,
-      /*afterInitialization=*/nullptr,
-      /*onEachMove=*/nullptr
+      /*shouldPause=*/NULL,
+      /*checkForNewNNEval=*/NULL,
+      /*afterInitialization=*/NULL,
+      /*onEachMove=*/NULL
     );
 
     double outcome = 0.5;
-    if(gameData != nullptr) {
+    if(gameData != NULL) {
       Player winner = gameData->endHist.winner;
       if(expIsBlack) {
         if(winner == P_BLACK)       { outcome = 1.0; wins++; }
@@ -297,7 +297,7 @@ int MainCmds::tuneparams(const vector<string>& args) {
 
     tuner.addResult(sample, outcome);
 
-    // Progress report every 100 trials
+    //Progress report every 100 trials
     if((trial + 1) % 100 == 0) {
       vector<double> vBest = tuner.bestCoords();
       double bE, bLog, bStdev;
@@ -312,7 +312,7 @@ int MainCmds::tuneparams(const vector<string>& args) {
     }
   }
 
-  // --- Final result ---
+  //Final result
   vector<double> vBest = tuner.bestCoords();
   double bestE, bestLog, bestStdev;
   qrsToPUCT(vBest, bestE, bestLog, bestStdev, qrsMins, qrsMaxs);
@@ -333,10 +333,10 @@ int MainCmds::tuneparams(const vector<string>& args) {
     Global::doubleToString(vBest[1]) + ", " + Global::doubleToString(vBest[2]) + "]"
   );
 
-  // --- ASCII-art regression curves (one per PUCT dimension) ---
+  //ASCII-art regression curves (one per PUCT dimension)
   printRegressionCurves(tuner, vBest, qrsMins, qrsMaxs, logger);
 
-  // --- Cleanup ---
+  //Cleanup
   delete gameRunner;
   for(NNEvaluator* eval : nnEvals)
     delete eval;

--- a/cpp/configs/tune_params_example.cfg
+++ b/cpp/configs/tune_params_example.cfg
@@ -1,0 +1,109 @@
+# Example config for tune-params (QRS-Tune PUCT hyperparameter tuning)
+# This is an example template config for the "tune-params" subcommand of KataGo. e.g:
+# ./katago tune-params -config configs/tune_params_example.cfg -log-file tune.log
+#
+# This command runs sequential head-to-head matches between a fixed reference bot (bot0)
+# and an experiment bot (bot1) whose PUCT parameters are adapted each trial using
+# QRS-Tune (Quadratic Regression Sequential optimization).
+#
+# After all trials, it reports the best-found values for cpuctExploration,
+# cpuctExplorationLog, and cpuctUtilityStdevPrior, along with ASCII regression curves
+# showing each parameter's estimated effect on win rate.
+#
+# See gtp config and match config for descriptions of most search and GPU params.
+
+# Tuning------------------------------------------------------------------------------------
+
+# Total number of tuning trials (games). More trials = better estimates but slower.
+# A few hundred trials is a reasonable starting point; 1000+ for higher confidence.
+numTrials = 500
+
+# Search ranges for PUCT parameters being tuned.
+# The optimizer explores within [Min, Max] for each parameter.
+# If omitted, defaults are used: cpuctExploration [0.5, 2.0], cpuctExplorationLog [0.05, 1.0],
+# cpuctUtilityStdevPrior [0.1, 0.8].
+# cpuctExplorationMin = 0.5
+# cpuctExplorationMax = 2.0
+# cpuctExplorationLogMin = 0.05
+# cpuctExplorationLogMax = 1.0
+# cpuctUtilityStdevPriorMin = 0.1
+# cpuctUtilityStdevPriorMax = 0.8
+
+# Logs------------------------------------------------------------------------------------
+
+logSearchInfo = false
+logMoves = false
+logGamesEvery = 100
+logToStdout = true
+
+# Bots-------------------------------------------------------------------------------------
+# Exactly 2 bots are required: bot0 = reference (fixed params), bot1 = experiment (tuned params).
+# Both bots can use the same model or different models.
+
+numBots = 2
+botName0 = base
+botName1 = experiment
+
+# Neural net model files - can be the same model for both bots
+nnModelFile0 = PATH_TO_MODEL
+nnModelFile1 = PATH_TO_MODEL
+
+# Match-----------------------------------------------------------------------------------
+
+numGameThreads = 8
+maxMovesPerGame = 1200
+
+allowResignation = true
+resignThreshold = -0.95
+resignConsecTurns = 6
+
+# Rules------------------------------------------------------------------------------------
+# Use a single fixed ruleset for consistent tuning results.
+
+koRules = SIMPLE
+scoringRules = AREA
+taxRules = NONE
+multiStoneSuicideLegals = false
+hasButtons = false
+
+bSizes = 19
+bSizeRelProbs = 1
+komiAuto = True
+handicapProb = 0.0
+handicapCompensateKomiProb = 1.0
+
+# Search limits-----------------------------------------------------------------------------------
+# Use fixed visits (not time) for reproducible results across trials.
+
+maxVisits = 500
+# maxVisits0 = 500
+# maxVisits1 = 500
+
+numSearchThreads = 1
+
+# GPU Settings-------------------------------------------------------------------------------
+
+nnMaxBatchSize = 32
+nnCacheSizePowerOfTwo = 21
+nnMutexPoolSizePowerOfTwo = 17
+nnRandomize = true
+numNNServerThreadsPerModel = 1
+
+# Root move selection and biases------------------------------------------------------------------------------
+
+chosenMoveTemperatureEarly = 0.60
+chosenMoveTemperature = 0.20
+
+# Internal params------------------------------------------------------------------------------
+# These are the FIXED params for bot0 (reference). Bot1's cpuctExploration,
+# cpuctExplorationLog, and cpuctUtilityStdevPrior will be overridden by the optimizer.
+
+# cpuctExploration = 0.9
+# cpuctExplorationLog = 0.4
+# cpuctUtilityStdevPrior = 0.40
+# fpuReductionMax = 0.2
+# rootFpuReductionMax = 0.1
+# valueWeightExponent = 0.25
+# subtreeValueBiasFactor = 0.45
+# subtreeValueBiasWeightExponent = 0.85
+# useGraphSearch = true

--- a/cpp/core/elo.cpp
+++ b/cpp/core/elo.cpp
@@ -277,7 +277,6 @@ bool ComputeElos::computeBradleyTerryElo(
   vector<double>& outStderr
 ) {
   int N = (int)botNames.size();
-  const double eloPerStrength = 400.0 * log10(exp(1.0)); //~173.7
 
   map<string,int> nameIdx;
   for(int i = 0; i < N; i++) nameIdx[botNames[i]] = i;
@@ -299,9 +298,13 @@ bool ComputeElos::computeBradleyTerryElo(
 
   bool converged = (M == 0);
   if(M > 0) {
+    vector<double> grad(M);
+    vector<vector<double>> H(M, vector<double>(M));
+    vector<vector<double>> aug(M, vector<double>(M+1));
+    vector<double> delta(M);
     for(int iter = 0; iter < 200; iter++) {
-      vector<double> grad(M, 0.0);
-      vector<vector<double>> H(M, vector<double>(M, 0.0));
+      fill(grad.begin(), grad.end(), 0.0);
+      for(int r = 0; r < M; r++) fill(H[r].begin(), H[r].end(), 0.0);
       for(int i = 0; i < N; i++) {
         for(int j = i+1; j < N; j++) {
           double nij = w[i][j] + w[j][i];
@@ -315,7 +318,6 @@ bool ComputeElos::computeBradleyTerryElo(
         }
       }
       //Solve H*delta = -grad via Gaussian elimination
-      vector<vector<double>> aug(M, vector<double>(M+1, 0.0));
       for(int r = 0; r < M; r++) {
         for(int c = 0; c < M; c++) aug[r][c] = H[r][c];
         aug[r][M] = -grad[r];
@@ -332,7 +334,7 @@ bool ComputeElos::computeBradleyTerryElo(
           for(int c = col; c <= M; c++) aug[r][c] -= f * aug[col][c];
         }
       }
-      vector<double> delta(M, 0.0);
+      fill(delta.begin(), delta.end(), 0.0);
       for(int r = M-1; r >= 0; r--) {
         double s = aug[r][M];
         for(int c = r+1; c < M; c++) s -= aug[r][c] * delta[c];
@@ -351,7 +353,7 @@ bool ComputeElos::computeBradleyTerryElo(
   outElo.resize(N);
   outStderr.resize(N, 0.0);
   for(int i = 0; i < N; i++)
-    outElo[i] = (theta[i] - theta[0]) * eloPerStrength;
+    outElo[i] = (theta[i] - theta[0]) * ELO_PER_LOG_GAMMA;
 
   //Fisher information diagonal -> stderr
   for(int i = 1; i < N; i++) {
@@ -363,7 +365,7 @@ bool ComputeElos::computeBradleyTerryElo(
       double sigma = 1.0 / (1.0 + exp(theta[j] - theta[i]));
       fish += nij * sigma * (1.0 - sigma);
     }
-    if(fish > 0.0) outStderr[i] = eloPerStrength / sqrt(fish);
+    if(fish > 0.0) outStderr[i] = ELO_PER_LOG_GAMMA / sqrt(fish);
   }
   return converged;
 }

--- a/cpp/core/elo.cpp
+++ b/cpp/core/elo.cpp
@@ -1,6 +1,8 @@
 #include "../core/elo.h"
 
+#include <array>
 #include <cmath>
+#include <map>
 
 #include "../core/test.h"
 #include "../core/os.h"
@@ -266,6 +268,104 @@ vector<double> ComputeElos::computeElos(
   }
 
   return elos;
+}
+
+bool ComputeElos::computeBradleyTerryElo(
+  const vector<string>& botNames,
+  const map<pair<string,string>, array<int64_t,3>>& pairStats,
+  vector<double>& outElo,
+  vector<double>& outStderr
+) {
+  int N = (int)botNames.size();
+  const double eloPerStrength = 400.0 * log10(exp(1.0)); //~173.7
+
+  map<string,int> nameIdx;
+  for(int i = 0; i < N; i++) nameIdx[botNames[i]] = i;
+
+  //w[i][j] = effective wins of i vs j (draws count 0.5)
+  vector<vector<double>> w(N, vector<double>(N, 0.0));
+  for(auto& kv : pairStats) {
+    auto itA = nameIdx.find(kv.first.first);
+    auto itB = nameIdx.find(kv.first.second);
+    if(itA == nameIdx.end() || itB == nameIdx.end()) continue;
+    int a = itA->second, b = itB->second;
+    w[a][b] += kv.second[0] + 0.5 * kv.second[2];
+    w[b][a] += kv.second[1] + 0.5 * kv.second[2];
+  }
+
+  //theta[0] = 0 (reference, first bot), optimize theta[1..N-1]
+  vector<double> theta(N, 0.0);
+  int M = N - 1;
+
+  bool converged = (M == 0);
+  if(M > 0) {
+    for(int iter = 0; iter < 200; iter++) {
+      vector<double> grad(M, 0.0);
+      vector<vector<double>> H(M, vector<double>(M, 0.0));
+      for(int i = 0; i < N; i++) {
+        for(int j = i+1; j < N; j++) {
+          double nij = w[i][j] + w[j][i];
+          if(nij <= 0.0) continue;
+          double sigma = 1.0 / (1.0 + exp(theta[j] - theta[i]));
+          double fish = nij * sigma * (1.0 - sigma);
+          double gij = w[i][j] - nij * sigma;
+          if(i > 0) { grad[i-1] += gij; H[i-1][i-1] -= fish; }
+          if(j > 0) { grad[j-1] -= gij; H[j-1][j-1] -= fish; }
+          if(i > 0 && j > 0) { H[i-1][j-1] += fish; H[j-1][i-1] += fish; }
+        }
+      }
+      //Solve H*delta = -grad via Gaussian elimination
+      vector<vector<double>> aug(M, vector<double>(M+1, 0.0));
+      for(int r = 0; r < M; r++) {
+        for(int c = 0; c < M; c++) aug[r][c] = H[r][c];
+        aug[r][M] = -grad[r];
+      }
+      for(int col = 0; col < M; col++) {
+        int piv = col;
+        for(int r = col+1; r < M; r++)
+          if(fabs(aug[r][col]) > fabs(aug[piv][col])) piv = r;
+        swap(aug[col], aug[piv]);
+        if(fabs(aug[col][col]) < 1e-12) continue;
+        double inv = 1.0 / aug[col][col];
+        for(int r = col+1; r < M; r++) {
+          double f = aug[r][col] * inv;
+          for(int c = col; c <= M; c++) aug[r][c] -= f * aug[col][c];
+        }
+      }
+      vector<double> delta(M, 0.0);
+      for(int r = M-1; r >= 0; r--) {
+        double s = aug[r][M];
+        for(int c = r+1; c < M; c++) s -= aug[r][c] * delta[c];
+        if(fabs(aug[r][r]) > 1e-12) delta[r] = s / aug[r][r];
+      }
+      double maxDelta = 0.0;
+      for(int r = 0; r < M; r++) {
+        theta[r+1] += delta[r];
+        maxDelta = max(maxDelta, fabs(delta[r]));
+      }
+      if(maxDelta < 1e-6) { converged = true; break; }
+    }
+  }
+
+  //Convert log-strength to Elo relative to bot 0
+  outElo.resize(N);
+  outStderr.resize(N, 0.0);
+  for(int i = 0; i < N; i++)
+    outElo[i] = (theta[i] - theta[0]) * eloPerStrength;
+
+  //Fisher information diagonal -> stderr
+  for(int i = 1; i < N; i++) {
+    double fish = 0.0;
+    for(int j = 0; j < N; j++) {
+      if(j == i) continue;
+      double nij = w[i][j] + w[j][i];
+      if(nij <= 0.0) continue;
+      double sigma = 1.0 / (1.0 + exp(theta[j] - theta[i]));
+      fish += nij * sigma * (1.0 - sigma);
+    }
+    if(fish > 0.0) outStderr[i] = eloPerStrength / sqrt(fish);
+  }
+  return converged;
 }
 
 static bool approxEqual(double x, double y, double tolerance) {

--- a/cpp/core/elo.h
+++ b/cpp/core/elo.h
@@ -3,6 +3,9 @@
 
 #include "../core/global.h"
 
+#include <array>
+#include <map>
+
 namespace ComputeElos {
   STRUCT_NAMED_PAIR(double,firstWins,double,secondWins,WLRecord);
     
@@ -29,6 +32,16 @@ namespace ComputeElos {
 
   //What's the probability of winning correspnding to this elo difference?
   double probWin(double eloDiff);
+
+  //Bradley-Terry MLE Elo via Newton-Raphson, for symmetric pairwise W/L/D data.
+  //pairStats: {nameA,nameB} -> {winsA, winsB, draws}, nameA < nameB lexicographically.
+  //Draws count as 0.5 wins for each side. Returns true if converged.
+  bool computeBradleyTerryElo(
+    const std::vector<std::string>& botNames,
+    const std::map<std::pair<std::string,std::string>, std::array<int64_t,3>>& pairStats,
+    std::vector<double>& outElo,
+    std::vector<double>& outStderr
+  );
 
   void runTests();
 }

--- a/cpp/core/fancymath.cpp
+++ b/cpp/core/fancymath.cpp
@@ -148,6 +148,22 @@ double FancyMath::binaryCrossEntropy(double predProb, double targetProb, double 
   return targetProb * (-log(predProb)) + (1.0-targetProb) * (-log(reverseProb));
 }
 
+void FancyMath::wilsonCI95(double wins, double n, double& lo, double& hi) {
+  const double z = 1.96;
+  double p = wins / n;
+  double denom = 1.0 + z*z/n;
+  double center = (p + z*z/(2*n)) / denom;
+  double margin = z * sqrt(p*(1-p)/n + z*z/(4*n*n)) / denom;
+  lo = center - margin;
+  hi = center + margin;
+}
+
+double FancyMath::oneTailedPValue(double wins, double n) {
+  if(n <= 0) return 0.5;
+  double z = (wins - 0.5*n) / (0.5*sqrt(n));
+  return 0.5 * erfc(z / sqrt(2.0));
+}
+
 
 #define APPROX_EQ(x,y,tolerance) testApproxEq((x),(y),(tolerance), #x, #y, __FILE__, __LINE__)
 static void testApproxEq(double x, double y, double tolerance, const char* msgX, const char* msgY, const char *file, int line) {

--- a/cpp/core/fancymath.cpp
+++ b/cpp/core/fancymath.cpp
@@ -149,6 +149,7 @@ double FancyMath::binaryCrossEntropy(double predProb, double targetProb, double 
 }
 
 void FancyMath::wilsonCI95(double wins, double n, double& lo, double& hi) {
+  if(n <= 0) { lo = 0; hi = 1; return; }
   const double z = 1.96;
   double p = wins / n;
   double denom = 1.0 + z*z/n;

--- a/cpp/core/fancymath.h
+++ b/cpp/core/fancymath.h
@@ -26,6 +26,13 @@ namespace FancyMath {
   //predProb is scaled into the range [epsilon,1.0-epsilon].
   double binaryCrossEntropy(double predProb, double targetProb, double epsilon);
 
+  //Wilson score 95% two-tailed confidence interval for binomial proportion.
+  //Draws should be counted as 0.5 wins before calling.
+  void wilsonCI95(double wins, double n, double& lo, double& hi);
+
+  //One-tailed p-value: P(observed winrate <= 0.5 | data), using normal approximation.
+  double oneTailedPValue(double wins, double n);
+
   void runTests();
 }
 

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -33,6 +33,7 @@ genconfig : User-friendly interface to generate a config with rules and automati
 contribute : Connect to online distributed KataGo training and run perpetually contributing selfplay games.
 
 match : Run self-play match games based on a config, more efficient than gtp due to batching.
+tune-params : Tune KataGo PUCT hyperparameters via sequential optimization (QRS-Tune).
 version : Print version and exit.
 
 analysis : Runs an engine designed to analyze entire games in parallel.
@@ -87,6 +88,8 @@ static int handleSubcommand(const string& subcommand, const vector<string>& args
     return MainCmds::tuner(subArgs);
   else if(subcommand == "match")
     return MainCmds::match(subArgs);
+  else if(subcommand == "tune-params")
+    return MainCmds::tuneparams(subArgs);
   else if(subcommand == "selfplay")
     return MainCmds::selfplay(subArgs);
   else if(subcommand == "testgpuerror")

--- a/cpp/main.h
+++ b/cpp/main.h
@@ -10,6 +10,7 @@ namespace MainCmds {
   int gtp(const std::vector<std::string>& args);
   int tuner(const std::vector<std::string>& args);
   int match(const std::vector<std::string>& args);
+  int tuneparams(const std::vector<std::string>& args);
   int selfplay(const std::vector<std::string>& args);
 
   int testgpuerror(const std::vector<std::string>& args);

--- a/cpp/qrstune/QRSOptimizer.cpp
+++ b/cpp/qrstune/QRSOptimizer.cpp
@@ -1,11 +1,31 @@
 // qrstune/QRSOptimizer.cpp
+//
+// QRS-Tune: Quadratic Response Surface optimizer for binary-outcome tuning.
+//
+// Models win probability as sigmoid(phi(x)^T * beta) where phi(x) is a
+// quadratic feature map: [1, x_i, x_i^2, x_i*x_j]. The model is fit via
+// Newton-Raphson MAP estimation with L2 regularization. The MAP optimum
+// of the fitted quadratic surface is used as the next evaluation point,
+// with decaying Gaussian noise for exploration.
 
 #include "../qrstune/QRSOptimizer.h"
 
 #include <algorithm>
 #include <cmath>
+#include <iostream>
+
+#include "../core/test.h"
 
 using namespace std;
+
+// Pivot values smaller than this are treated as singular
+static const double SINGULAR_THRESHOLD = 1e-12;
+
+// Newton-Raphson stops when the largest coefficient change is below this
+static const double CONVERGENCE_THRESHOLD = 1e-7;
+
+// Sigmoid is clamped to 0 or 1 beyond this magnitude to avoid overflow
+static const double SIGMOID_CLAMP = 40.0;
 
 // ============================================================
 // Free functions
@@ -15,6 +35,9 @@ int QRSTune::numFeatures(int D) {
   return 1 + D + D * (D + 1) / 2;
 }
 
+// Feature layout for D dimensions:
+//   [intercept(1), linear(D), quadratic(D), cross-terms(D*(D-1)/2)]
+// Example for D=2, x=[a,b]: phi = [1, a, b, a^2, b^2, a*b]
 void QRSTune::computeFeatures(int D, const double* x, double* phi) {
   int k = 0;
   phi[k++] = 1.0;
@@ -26,26 +49,31 @@ void QRSTune::computeFeatures(int D, const double* x, double* phi) {
 }
 
 double QRSTune::sigmoid(double z) {
-  if(z > 40.0) return 1.0;
-  if(z < -40.0) return 0.0;
+  if(z > SIGMOID_CLAMP) return 1.0;
+  if(z < -SIGMOID_CLAMP) return 0.0;
   return 1.0 / (1.0 + exp(-z));
 }
 
+// Partial-pivot Gaussian elimination: solves Ax = b in-place.
+// On return, b contains the solution x. A is destroyed.
+// Returns false if A is singular (pivot below SINGULAR_THRESHOLD).
 bool QRSTune::gaussianSolve(int F, vector<vector<double>>& A, vector<double>& b) {
+  // Forward elimination with partial pivoting
   for(int col = 0; col < F; col++) {
     int piv = col;
     for(int r = col + 1; r < F; r++)
       if(fabs(A[r][col]) > fabs(A[piv][col])) piv = r;
     swap(A[col], A[piv]);
     swap(b[col], b[piv]);
-    if(fabs(A[col][col]) < 1e-12) return false;
+    if(fabs(A[col][col]) < SINGULAR_THRESHOLD) return false;
     double inv = 1.0 / A[col][col];
     for(int r = col + 1; r < F; r++) {
-      double f = A[r][col] * inv;
-      for(int c = col; c < F; c++) A[r][c] -= f * A[col][c];
-      b[r] -= f * b[col];
+      double mult = A[r][col] * inv;
+      for(int c = col; c < F; c++) A[r][c] -= mult * A[col][c];
+      b[r] -= mult * b[col];
     }
   }
+  // Back substitution
   for(int r = F - 1; r >= 0; r--) {
     for(int c = r + 1; c < F; c++) b[r] -= A[r][c] * b[c];
     b[r] /= A[r][r];
@@ -70,6 +98,16 @@ QRSTune::QRSModel::QRSModel(int D, double l2_reg)
    l2_(l2_reg)
 {}
 
+// Newton-Raphson MAP estimation for L2-regularized quadratic logistic regression.
+//
+// Maximizes: sum_n [ y_n * log(p_n) + (1-y_n) * log(1-p_n) ] - (l2/2) * ||beta||^2
+// where p_n = sigmoid(phi(x_n)^T * beta).
+//
+// Each iteration:
+//   1. Compute gradient and negative Hessian (including L2 prior)
+//   2. Solve the Newton system: negH * delta = grad
+//   3. Update: beta += delta
+//   4. Stop when max |delta_f| < CONVERGENCE_THRESHOLD
 void QRSTune::QRSModel::fit(const vector<vector<double>>& xs,
                              const vector<double>& ys,
                              int max_iter) {
@@ -81,7 +119,7 @@ void QRSTune::QRSModel::fit(const vector<vector<double>>& xs,
   vector<vector<double>> negH(F_, vector<double>(F_));
 
   for(int iter = 0; iter < max_iter; iter++) {
-    // Gradient and (negative) Hessian from L2 prior
+    // Initialize with L2 prior contribution: grad = -l2*beta, negH = l2*I
     fill(grad.begin(), grad.end(), 0.0);
     for(int f = 0; f < F_; f++) fill(negH[f].begin(), negH[f].end(), 0.0);
     for(int f = 0; f < F_; f++) {
@@ -89,33 +127,35 @@ void QRSTune::QRSModel::fit(const vector<vector<double>>& xs,
       negH[f][f] = l2_;
     }
 
-    // Data contribution
+    // Accumulate data likelihood: grad += (y-p)*phi, negH += p*(1-p)*phi*phi^T
     for(int n = 0; n < N; n++) {
       computeFeatures(D_, xs[n].data(), phi.data());
-      double z = 0.0;
-      for(int f = 0; f < F_; f++) z += beta_[f] * phi[f];
-      double p = sigmoid(z);
-      double w = p * (1.0 - p);
-      double resid = ys[n] - p;
+      double logit = 0.0;
+      for(int f = 0; f < F_; f++) logit += beta_[f] * phi[f];
+      double p = sigmoid(logit);
+      double hessianWeight = p * (1.0 - p);
+      double residual = ys[n] - p;
       for(int f = 0; f < F_; f++) {
-        grad[f] += resid * phi[f];
+        grad[f] += residual * phi[f];
         for(int g = f; g < F_; g++)
-          negH[f][g] += w * phi[f] * phi[g];
+          negH[f][g] += hessianWeight * phi[f] * phi[g];
       }
     }
-    // Symmetrize negH
+    // Symmetrize: negH is only filled for g >= f above
     for(int f = 0; f < F_; f++)
       for(int g = f + 1; g < F_; g++)
         negH[g][f] = negH[f][g];
 
-    // Solve negH * delta = grad  =>  beta += delta
+    // Solve Newton step: negH * delta = grad (grad is overwritten with delta)
     if(!gaussianSolve(F_, negH, grad)) break;
-    double maxd = 0.0;
+
+    // Apply step and check convergence
+    double maxStep = 0.0;
     for(int f = 0; f < F_; f++) {
       beta_[f] += grad[f];
-      maxd = max(maxd, fabs(grad[f]));
+      maxStep = max(maxStep, fabs(grad[f]));
     }
-    if(maxd < 1e-7) break;
+    if(maxStep < CONVERGENCE_THRESHOLD) break;
   }
 }
 
@@ -126,29 +166,34 @@ double QRSTune::QRSModel::predict(const double* x) const {
 double QRSTune::QRSModel::score(const double* x) const {
   vector<double> phi(F_);
   computeFeatures(D_, x, phi.data());
-  double z = 0.0;
-  for(int f = 0; f < F_; f++) z += beta_[f] * phi[f];
-  return z;
+  double logit = 0.0;
+  for(int f = 0; f < F_; f++) logit += beta_[f] * phi[f];
+  return logit;
 }
 
+// Find the unconstrained optimum of the quadratic score surface, then clamp to [-1,+1]^D.
+//
+// Beta layout: [intercept, linear[0..D-1], quadratic[0..D-1], cross[i<j]]
+// The quadratic surface gradient is: M*x + linearCoeffs = 0
+// where M[i][i] = 2*quadCoeffs[i], M[i][j] = crossCoeffs[pair(i,j)]
 void QRSTune::QRSModel::mapOptimum(double* out_x) const {
-  // Beta layout: [intercept, linear[0..D-1], quad[0..D-1], cross by (i<j)]
-  const double* b_lin  = beta_.data() + 1;
-  const double* b_quad = beta_.data() + 1 + D_;
-  const double* b_cross = beta_.data() + 1 + 2 * D_;
+  const double* linearCoeffs = beta_.data() + 1;
+  const double* quadCoeffs   = beta_.data() + 1 + D_;
+  const double* crossCoeffs  = beta_.data() + 1 + 2 * D_;
 
+  // Build the Hessian matrix M and right-hand side for M*x = -linearCoeffs
   vector<vector<double>> M(D_, vector<double>(D_, 0.0));
   vector<double> rhs(D_);
 
   for(int k = 0; k < D_; k++) {
-    M[k][k] = 2.0 * b_quad[k];
-    rhs[k]  = -b_lin[k];
+    M[k][k] = 2.0 * quadCoeffs[k];
+    rhs[k]  = -linearCoeffs[k];
   }
   int idx = 0;
   for(int i = 0; i < D_; i++)
     for(int j = i + 1; j < D_; j++) {
-      M[i][j] += b_cross[idx];
-      M[j][i] += b_cross[idx];
+      M[i][j] += crossCoeffs[idx];
+      M[j][i] += crossCoeffs[idx];
       idx++;
     }
 
@@ -156,6 +201,7 @@ void QRSTune::QRSModel::mapOptimum(double* out_x) const {
     for(int i = 0; i < D_; i++) out_x[i] = 0.0;
     return;
   }
+  // Clamp to the normalized coordinate range [-1, +1]
   for(int i = 0; i < D_; i++)
     out_x[i] = max(-1.0, min(1.0, rhs[i]));
 }
@@ -174,47 +220,51 @@ void QRSTune::QRSBuffer::add(const vector<double>& x, double y) {
   ys_.push_back(y);
 }
 
+// Confidence-based pruning: drop samples whose predicted win rate
+// is more than prune_margin_ below the best predicted win rate.
+// Samples are ranked so that min_keep_ retains the highest-quality
+// samples (not just the oldest).
 void QRSTune::QRSBuffer::prune(const QRSModel& model) {
   int N = (int)xs_.size();
   if(N <= min_keep_ * 2) return;
 
   // Score all samples and find best predicted win rate
-  vector<pair<double, int>> scored(N);
-  double p_best = 0.0;
+  vector<pair<double, int>> scored(N);  // (predicted winrate, original index)
+  double bestPrediction = 0.0;
   for(int i = 0; i < N; i++) {
     double p = model.predict(xs_[i].data());
     scored[i] = {p, i};
-    if(p > p_best) p_best = p;
+    if(p > bestPrediction) bestPrediction = p;
   }
-  double threshold = p_best - prune_margin_;
+  double threshold = bestPrediction - prune_margin_;
 
-  // Sort by descending predicted quality
+  // Sort by descending predicted quality so min_keep_ retains the best
   sort(scored.begin(), scored.end(),
     [](const pair<double,int>& a, const pair<double,int>& b) {
       return a.first > b.first;
     });
 
-  // Keep samples above threshold, plus top-quality samples up to min_keep_
+  // Mark samples to keep: above threshold, or among top min_keep_
   vector<bool> keep(N, false);
   int kept = 0;
-  for(auto& kv : scored) {
-    if(kv.first >= threshold || kept < min_keep_) {
-      keep[kv.second] = true;
+  for(auto& entry : scored) {
+    if(entry.first >= threshold || kept < min_keep_) {
+      keep[entry.second] = true;
       kept++;
     }
   }
 
   // Rebuild in original order to preserve temporal structure
-  vector<vector<double>> nx;
-  vector<double> ny;
+  vector<vector<double>> newXs;
+  vector<double> newYs;
   for(int i = 0; i < N; i++) {
     if(keep[i]) {
-      nx.push_back(std::move(xs_[i]));
-      ny.push_back(ys_[i]);
+      newXs.push_back(std::move(xs_[i]));
+      newYs.push_back(ys_[i]);
     }
   }
-  xs_ = std::move(nx);
-  ys_ = std::move(ny);
+  xs_ = std::move(newXs);
+  ys_ = std::move(newYs);
 }
 
 // ============================================================
@@ -247,10 +297,8 @@ vector<double> QRSTune::QRSTuner::nextSample() {
     return x;
   }
 
-  // Base: MAP optimum
+  // Start from MAP optimum, add decaying Gaussian noise for exploration
   model_.mapOptimum(x.data());
-
-  // Decaying exploration noise
   double progress = (double)trial_count_ / max(1, total_trials_ - 1);
   double sigma = sigma_initial_ + progress * (sigma_final_ - sigma_initial_);
   normal_distribution<double> noise(0.0, sigma);
@@ -281,4 +329,190 @@ vector<double> QRSTune::QRSTuner::bestCoords() const {
 double QRSTune::QRSTuner::bestWinProb() const {
   auto best = bestCoords();
   return model_.predict(best.data());
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+static bool approxEqual(double x, double y, double tolerance) {
+  return fabs(x - y) < tolerance;
+}
+
+void QRSTune::runTests() {
+  cout << "Running QRSTune tests" << endl;
+
+  // Test numFeatures: F = 1 + D + D*(D+1)/2
+  // D=0: 1, D=1: 3, D=2: 6, D=3: 10
+  {
+    testAssert(numFeatures(0) == 1);
+    testAssert(numFeatures(1) == 3);
+    testAssert(numFeatures(2) == 6);
+    testAssert(numFeatures(3) == 10);
+  }
+
+  // Test computeFeatures: D=2, x=[0.5, -0.3]
+  // Expected: [1.0, 0.5, -0.3, 0.25, 0.09, -0.15]
+  {
+    double x[2] = {0.5, -0.3};
+    double phi[6];
+    computeFeatures(2, x, phi);
+    testAssert(approxEqual(phi[0], 1.0, 1e-15));
+    testAssert(approxEqual(phi[1], 0.5, 1e-15));
+    testAssert(approxEqual(phi[2], -0.3, 1e-15));
+    testAssert(approxEqual(phi[3], 0.25, 1e-15));
+    testAssert(approxEqual(phi[4], 0.09, 1e-15));
+    testAssert(approxEqual(phi[5], -0.15, 1e-15));
+  }
+
+  // Test sigmoid
+  {
+    testAssert(approxEqual(sigmoid(0.0), 0.5, 1e-15));
+    testAssert(sigmoid(50.0) == 1.0);
+    testAssert(sigmoid(-50.0) == 0.0);
+    testAssert(approxEqual(sigmoid(1.0), 1.0 / (1.0 + exp(-1.0)), 1e-12));
+    // Beyond clamp threshold: exactly 0 or 1
+    testAssert(sigmoid(SIGMOID_CLAMP + 1.0) == 1.0);
+    testAssert(sigmoid(-SIGMOID_CLAMP - 1.0) == 0.0);
+    // Moderate values: still fractional
+    testAssert(sigmoid(5.0) < 1.0);
+    testAssert(sigmoid(-5.0) > 0.0);
+  }
+
+  // Test gaussianSolve: 2x2 system [[2,1],[1,3]] * x = [5,7] => x = [8/5, 9/5]
+  {
+    vector<vector<double>> A = {{2.0, 1.0}, {1.0, 3.0}};
+    vector<double> b = {5.0, 7.0};
+    bool ok = gaussianSolve(2, A, b);
+    testAssert(ok);
+    testAssert(approxEqual(b[0], 8.0 / 5.0, 1e-12));
+    testAssert(approxEqual(b[1], 9.0 / 5.0, 1e-12));
+  }
+
+  // Test gaussianSolve: 3x3 identity system
+  {
+    vector<vector<double>> A = {{1,0,0},{0,1,0},{0,0,1}};
+    vector<double> b = {3.0, -1.0, 7.0};
+    bool ok = gaussianSolve(3, A, b);
+    testAssert(ok);
+    testAssert(approxEqual(b[0], 3.0, 1e-15));
+    testAssert(approxEqual(b[1], -1.0, 1e-15));
+    testAssert(approxEqual(b[2], 7.0, 1e-15));
+  }
+
+  // Test gaussianSolve: singular matrix returns false
+  {
+    vector<vector<double>> A = {{1.0, 2.0}, {2.0, 4.0}};
+    vector<double> b = {3.0, 6.0};
+    bool ok = gaussianSolve(2, A, b);
+    testAssert(!ok);
+  }
+
+  // Test QRSModel fit + predict: 1D separable data
+  // All samples at x=+0.8 win, all at x=-0.8 lose.
+  // After fitting, predict(+0.8) should be high and predict(-0.8) should be low.
+  {
+    QRSModel model(1, 0.1);
+    vector<vector<double>> xs;
+    vector<double> ys;
+    for(int i = 0; i < 20; i++) {
+      xs.push_back({0.8});
+      ys.push_back(1.0);
+      xs.push_back({-0.8});
+      ys.push_back(0.0);
+    }
+    model.fit(xs, ys);
+    double xWin[] = {0.8};
+    double xLose[] = {-0.8};
+    double xMid[] = {0.0};
+    double pWin = model.predict(xWin);
+    double pLose = model.predict(xLose);
+    testAssert(pWin > 0.7);
+    testAssert(pLose < 0.3);
+    // Midpoint should be near 0.5
+    double pMid = model.predict(xMid);
+    testAssert(approxEqual(pMid, 0.5, 0.15));
+  }
+
+  // Test QRSModel mapOptimum: after fitting 1D win-at-positive data,
+  // the MAP optimum should be in the positive region (clamped to [−1,+1]).
+  {
+    QRSModel model(1, 0.1);
+    vector<vector<double>> xs;
+    vector<double> ys;
+    for(int i = 0; i < 20; i++) {
+      xs.push_back({0.8});
+      ys.push_back(1.0);
+      xs.push_back({-0.8});
+      ys.push_back(0.0);
+    }
+    model.fit(xs, ys);
+    double bestX;
+    model.mapOptimum(&bestX);
+    // The optimum should have a higher predicted win rate than the anti-optimum
+    double negOne = -1.0;
+    testAssert(model.predict(&bestX) > model.predict(&negOne) + 0.1);
+  }
+
+  // Test QRSModel 2D: wins cluster at (+0.5, +0.5), losses at (-0.5, -0.5)
+  {
+    QRSModel model(2, 0.1);
+    vector<vector<double>> xs;
+    vector<double> ys;
+    for(int i = 0; i < 20; i++) {
+      xs.push_back({0.5, 0.5});
+      ys.push_back(1.0);
+      xs.push_back({-0.5, -0.5});
+      ys.push_back(0.0);
+    }
+    model.fit(xs, ys);
+    double xWin[] = {0.5, 0.5};
+    double xLose[] = {-0.5, -0.5};
+    double pWin = model.predict(xWin);
+    double pLose = model.predict(xLose);
+    testAssert(pWin > 0.7);
+    testAssert(pLose < 0.3);
+  }
+
+  // Test QRSTuner end-to-end: 1D, deterministic seed, outcome strongly correlated
+  // with x > 0. After enough trials the best predicted win rate should exceed 0.5.
+  {
+    const int numTrials = 100;
+    QRSTuner tuner(1, /*seed=*/42, numTrials,
+                   /*l2_reg=*/0.1, /*refit_every=*/10, /*prune_every=*/5);
+    for(int trial = 0; trial < numTrials; trial++) {
+      vector<double> sample = tuner.nextSample();
+      // Strong signal: win when x > 0, lose when x < 0
+      double outcome = (sample[0] > 0.0) ? 1.0 : 0.0;
+      tuner.addResult(sample, outcome);
+    }
+    testAssert(tuner.trialCount() == numTrials);
+    // The fitted model should recognize that positive x is better
+    testAssert(tuner.bestWinProb() > 0.5);
+  }
+
+  // Test QRSBuffer prune: verify pruning reduces buffer size
+  {
+    QRSModel model(1, 0.1);
+    vector<vector<double>> xs;
+    vector<double> ys;
+    // Build data with a clear win region
+    for(int i = 0; i < 30; i++) {
+      xs.push_back({0.8});
+      ys.push_back(1.0);
+      xs.push_back({-0.8});
+      ys.push_back(0.0);
+    }
+    model.fit(xs, ys);
+
+    QRSBuffer buffer(5, 0.10);  // tight margin, keep at least 5
+    for(int i = 0; i < 60; i++) {
+      buffer.add(xs[i], ys[i]);
+    }
+    testAssert(buffer.size() == 60);
+    buffer.prune(model);
+    // Should have pruned some low-quality samples
+    testAssert(buffer.size() < 60);
+    testAssert(buffer.size() >= 5);  // min_keep
+  }
 }

--- a/cpp/qrstune/QRSOptimizer.cpp
+++ b/cpp/qrstune/QRSOptimizer.cpp
@@ -1,0 +1,282 @@
+// qrstune/QRSOptimizer.cpp
+
+#include "../qrstune/QRSOptimizer.h"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace std;
+
+// ============================================================
+// Free functions
+// ============================================================
+
+int QRSTune::numFeatures(int D) {
+  return 1 + D + D * (D + 1) / 2;
+}
+
+void QRSTune::computeFeatures(int D, const double* x, double* phi) {
+  int k = 0;
+  phi[k++] = 1.0;
+  for(int i = 0; i < D; i++) phi[k++] = x[i];
+  for(int i = 0; i < D; i++) phi[k++] = x[i] * x[i];
+  for(int i = 0; i < D; i++)
+    for(int j = i + 1; j < D; j++)
+      phi[k++] = x[i] * x[j];
+}
+
+double QRSTune::sigmoid(double z) {
+  if(z > 40.0) return 1.0;
+  if(z < -40.0) return 0.0;
+  return 1.0 / (1.0 + exp(-z));
+}
+
+bool QRSTune::gaussianSolve(int F, vector<vector<double>>& A, vector<double>& b) {
+  for(int col = 0; col < F; col++) {
+    int piv = col;
+    for(int r = col + 1; r < F; r++)
+      if(fabs(A[r][col]) > fabs(A[piv][col])) piv = r;
+    swap(A[col], A[piv]);
+    swap(b[col], b[piv]);
+    if(fabs(A[col][col]) < 1e-12) return false;
+    double inv = 1.0 / A[col][col];
+    for(int r = col + 1; r < F; r++) {
+      double f = A[r][col] * inv;
+      for(int c = col; c < F; c++) A[r][c] -= f * A[col][c];
+      b[r] -= f * b[col];
+    }
+  }
+  for(int r = F - 1; r >= 0; r--) {
+    for(int c = r + 1; c < F; c++) b[r] -= A[r][c] * b[c];
+    b[r] /= A[r][r];
+  }
+  return true;
+}
+
+// ============================================================
+// QRSModel
+// ============================================================
+
+QRSTune::QRSModel::QRSModel()
+  :D_(0),
+   F_(0),
+   l2_(0.1)
+{}
+
+QRSTune::QRSModel::QRSModel(int D, double l2_reg)
+  :D_(D),
+   F_(numFeatures(D)),
+   beta_(numFeatures(D), 0.0),
+   l2_(l2_reg)
+{}
+
+void QRSTune::QRSModel::fit(const vector<vector<double>>& xs,
+                             const vector<double>& ys,
+                             int max_iter) {
+  int N = (int)xs.size();
+  if(N < F_) return;  // underdetermined; keep prior beta = 0
+
+  vector<double> phi(F_);
+
+  for(int iter = 0; iter < max_iter; iter++) {
+    // Gradient and (negative) Hessian from L2 prior
+    vector<double> grad(F_, 0.0);
+    vector<vector<double>> negH(F_, vector<double>(F_, 0.0));
+    for(int f = 0; f < F_; f++) {
+      grad[f] = -l2_ * beta_[f];
+      negH[f][f] = l2_;
+    }
+
+    // Data contribution
+    for(int n = 0; n < N; n++) {
+      computeFeatures(D_, xs[n].data(), phi.data());
+      double z = 0.0;
+      for(int f = 0; f < F_; f++) z += beta_[f] * phi[f];
+      double p = sigmoid(z);
+      double w = p * (1.0 - p);
+      double resid = ys[n] - p;
+      for(int f = 0; f < F_; f++) {
+        grad[f] += resid * phi[f];
+        for(int g = f; g < F_; g++)
+          negH[f][g] += w * phi[f] * phi[g];
+      }
+    }
+    // Symmetrize negH
+    for(int f = 0; f < F_; f++)
+      for(int g = f + 1; g < F_; g++)
+        negH[g][f] = negH[f][g];
+
+    // Solve negH * delta = grad  =>  beta += delta
+    if(!gaussianSolve(F_, negH, grad)) break;
+    double maxd = 0.0;
+    for(int f = 0; f < F_; f++) {
+      beta_[f] += grad[f];
+      maxd = max(maxd, fabs(grad[f]));
+    }
+    if(maxd < 1e-7) break;
+  }
+}
+
+double QRSTune::QRSModel::predict(const double* x) const {
+  return sigmoid(score(x));
+}
+
+double QRSTune::QRSModel::score(const double* x) const {
+  vector<double> phi(F_);
+  computeFeatures(D_, x, phi.data());
+  double z = 0.0;
+  for(int f = 0; f < F_; f++) z += beta_[f] * phi[f];
+  return z;
+}
+
+void QRSTune::QRSModel::mapOptimum(double* out_x) const {
+  // Beta layout: [intercept, linear[0..D-1], quad[0..D-1], cross by (i<j)]
+  const double* b_lin  = beta_.data() + 1;
+  const double* b_quad = beta_.data() + 1 + D_;
+  const double* b_cross = beta_.data() + 1 + 2 * D_;
+
+  vector<vector<double>> M(D_, vector<double>(D_, 0.0));
+  vector<double> rhs(D_);
+
+  for(int k = 0; k < D_; k++) {
+    M[k][k] = 2.0 * b_quad[k];
+    rhs[k]  = -b_lin[k];
+  }
+  int idx = 0;
+  for(int i = 0; i < D_; i++)
+    for(int j = i + 1; j < D_; j++) {
+      M[i][j] += b_cross[idx];
+      M[j][i] += b_cross[idx];
+      idx++;
+    }
+
+  if(!gaussianSolve(D_, M, rhs)) {
+    for(int i = 0; i < D_; i++) out_x[i] = 0.0;
+    return;
+  }
+  for(int i = 0; i < D_; i++)
+    out_x[i] = max(-1.0, min(1.0, rhs[i]));
+}
+
+// ============================================================
+// QRSBuffer
+// ============================================================
+
+QRSTune::QRSBuffer::QRSBuffer(int min_keep, double prune_margin)
+  :min_keep_(min_keep),
+   prune_margin_(prune_margin)
+{}
+
+void QRSTune::QRSBuffer::add(const vector<double>& x, double y) {
+  xs_.push_back(x);
+  ys_.push_back(y);
+}
+
+void QRSTune::QRSBuffer::prune(const QRSModel& model) {
+  int N = (int)xs_.size();
+  if(N <= min_keep_ * 2) return;
+
+  // Score all samples and find best predicted win rate
+  vector<pair<double, int>> scored(N);
+  double p_best = 0.0;
+  for(int i = 0; i < N; i++) {
+    double p = model.predict(xs_[i].data());
+    scored[i] = {p, i};
+    if(p > p_best) p_best = p;
+  }
+  double threshold = p_best - prune_margin_;
+
+  // Sort by descending predicted quality
+  sort(scored.begin(), scored.end(),
+    [](const pair<double,int>& a, const pair<double,int>& b) {
+      return a.first > b.first;
+    });
+
+  // Keep samples above threshold, plus top-quality samples up to min_keep_
+  vector<bool> keep(N, false);
+  int kept = 0;
+  for(auto& kv : scored) {
+    if(kv.first >= threshold || kept < min_keep_) {
+      keep[kv.second] = true;
+      kept++;
+    }
+  }
+
+  // Rebuild in original order to preserve temporal structure
+  vector<vector<double>> nx;
+  vector<double> ny;
+  for(int i = 0; i < N; i++) {
+    if(keep[i]) {
+      nx.push_back(xs_[i]);
+      ny.push_back(ys_[i]);
+    }
+  }
+  xs_ = std::move(nx);
+  ys_ = std::move(ny);
+}
+
+// ============================================================
+// QRSTuner
+// ============================================================
+
+QRSTune::QRSTuner::QRSTuner(int D, uint64_t seed, int total_trials,
+                             double l2_reg, int refit_every, int prune_every,
+                             double sigma_init, double sigma_fin)
+  :D_(D),
+   model_(D, l2_reg),
+   buffer_(max(20, total_trials / 50), 0.25),
+   rng_(seed),
+   trial_count_(0),
+   total_trials_(total_trials),
+   refit_every_(refit_every),
+   prune_every_(prune_every),
+   sigma_initial_(sigma_init),
+   sigma_final_(sigma_fin)
+{}
+
+vector<double> QRSTune::QRSTuner::nextSample() {
+  vector<double> x(D_);
+  int F = model_.features();
+
+  if(buffer_.size() < F + 1) {
+    // Insufficient data for reliable fit — explore uniformly
+    uniform_real_distribution<double> uni(-1.0, 1.0);
+    for(int i = 0; i < D_; i++) x[i] = uni(rng_);
+    return x;
+  }
+
+  // Base: MAP optimum
+  model_.mapOptimum(x.data());
+
+  // Decaying exploration noise
+  double progress = (double)trial_count_ / max(1, total_trials_ - 1);
+  double sigma = sigma_initial_ + progress * (sigma_final_ - sigma_initial_);
+  normal_distribution<double> noise(0.0, sigma);
+  for(int i = 0; i < D_; i++)
+    x[i] = max(-1.0, min(1.0, x[i] + noise(rng_)));
+
+  return x;
+}
+
+void QRSTune::QRSTuner::addResult(const vector<double>& x, double y) {
+  buffer_.add(x, y);
+  trial_count_++;
+
+  if(trial_count_ % refit_every_ == 0 && buffer_.size() >= model_.features() + 1) {
+    model_.fit(buffer_.xs(), buffer_.ys());
+    int refit_count = trial_count_ / refit_every_;
+    if(refit_count % prune_every_ == 0)
+      buffer_.prune(model_);
+  }
+}
+
+vector<double> QRSTune::QRSTuner::bestCoords() const {
+  vector<double> best(D_);
+  model_.mapOptimum(best.data());
+  return best;
+}
+
+double QRSTune::QRSTuner::bestWinProb() const {
+  auto best = bestCoords();
+  return model_.predict(best.data());
+}

--- a/cpp/qrstune/QRSOptimizer.cpp
+++ b/cpp/qrstune/QRSOptimizer.cpp
@@ -77,11 +77,13 @@ void QRSTune::QRSModel::fit(const vector<vector<double>>& xs,
   if(N < F_) return;  // underdetermined; keep prior beta = 0
 
   vector<double> phi(F_);
+  vector<double> grad(F_);
+  vector<vector<double>> negH(F_, vector<double>(F_));
 
   for(int iter = 0; iter < max_iter; iter++) {
     // Gradient and (negative) Hessian from L2 prior
-    vector<double> grad(F_, 0.0);
-    vector<vector<double>> negH(F_, vector<double>(F_, 0.0));
+    fill(grad.begin(), grad.end(), 0.0);
+    for(int f = 0; f < F_; f++) fill(negH[f].begin(), negH[f].end(), 0.0);
     for(int f = 0; f < F_; f++) {
       grad[f] = -l2_ * beta_[f];
       negH[f][f] = l2_;
@@ -207,7 +209,7 @@ void QRSTune::QRSBuffer::prune(const QRSModel& model) {
   vector<double> ny;
   for(int i = 0; i < N; i++) {
     if(keep[i]) {
-      nx.push_back(xs_[i]);
+      nx.push_back(std::move(xs_[i]));
       ny.push_back(ys_[i]);
     }
   }

--- a/cpp/qrstune/QRSOptimizer.h
+++ b/cpp/qrstune/QRSOptimizer.h
@@ -41,7 +41,7 @@ static inline double sigmoid(double z) {
 
 // Solve Ax = b in-place (A is F x F, b is length F) via partial-pivot
 // Gaussian elimination. Returns false if singular. Overwrites A and b.
-static bool gaussianSolve(int F, std::vector<std::vector<double>>& A, std::vector<double>& b) {
+static inline bool gaussianSolve(int F, std::vector<std::vector<double>>& A, std::vector<double>& b) {
   for(int col = 0; col < F; col++) {
     int piv = col;
     for(int r = col + 1; r < F; r++)
@@ -204,23 +204,44 @@ class QRSBuffer {
   }
 
   // Remove samples significantly below the current MAP win estimate.
+  // Samples are ranked by predicted quality so that min_keep_ retains the
+  // best samples rather than the oldest (which are typically from early
+  // uniform random exploration).
   void prune(const QRSModel& model) {
     int N = (int)xs_.size();
     if(N <= min_keep_ * 2) return;
 
-    // Best predicted win rate across all stored samples
+    // Score all samples and find best predicted win rate
+    std::vector<std::pair<double, int>> scored(N);
     double p_best = 0.0;
     for(int i = 0; i < N; i++) {
       double p = model.predict(xs_[i].data());
+      scored[i] = {p, i};
       if(p > p_best) p_best = p;
     }
     double threshold = p_best - prune_margin_;
 
+    // Sort by descending predicted quality
+    std::sort(scored.begin(), scored.end(),
+      [](const std::pair<double,int>& a, const std::pair<double,int>& b) {
+        return a.first > b.first;
+      });
+
+    // Keep samples above threshold, plus top-quality samples up to min_keep_
+    std::vector<bool> keep(N, false);
+    int kept = 0;
+    for(auto& kv : scored) {
+      if(kv.first >= threshold || kept < min_keep_) {
+        keep[kv.second] = true;
+        kept++;
+      }
+    }
+
+    // Rebuild in original order to preserve temporal structure
     std::vector<std::vector<double>> nx;
     std::vector<double> ny;
     for(int i = 0; i < N; i++) {
-      double p = model.predict(xs_[i].data());
-      if(p >= threshold || (int)nx.size() < min_keep_) {
+      if(keep[i]) {
         nx.push_back(xs_[i]);
         ny.push_back(ys_[i]);
       }

--- a/cpp/qrstune/QRSOptimizer.h
+++ b/cpp/qrstune/QRSOptimizer.h
@@ -1,14 +1,11 @@
 // qrstune/QRSOptimizer.h
 
-#pragma once
+#ifndef QRSTUNE_QRSOPTIMIZER_H_
+#define QRSTUNE_QRSOPTIMIZER_H_
 
-#include <vector>
-#include <cmath>
-#include <algorithm>
-#include <cassert>
 #include <cstdint>
 #include <random>
-#include <stdexcept>
+#include <vector>
 
 namespace QRSTune {
 
@@ -18,50 +15,16 @@ namespace QRSTune {
 //   Total features F = 1 + D + D*(D+1)/2
 // ============================================================
 
-inline int numFeatures(int D) {
-  return 1 + D + D * (D + 1) / 2;
-}
+int numFeatures(int D);
 
 // Fill phi[0..F-1] given x[0..D-1].
-inline void computeFeatures(int D, const double* x, double* phi) {
-  int k = 0;
-  phi[k++] = 1.0;
-  for(int i = 0; i < D; i++) phi[k++] = x[i];
-  for(int i = 0; i < D; i++) phi[k++] = x[i] * x[i];
-  for(int i = 0; i < D; i++)
-    for(int j = i + 1; j < D; j++)
-      phi[k++] = x[i] * x[j];
-}
+void computeFeatures(int D, const double* x, double* phi);
 
-inline double sigmoid(double z) {
-  if(z > 40.0) return 1.0;
-  if(z < -40.0) return 0.0;
-  return 1.0 / (1.0 + std::exp(-z));
-}
+double sigmoid(double z);
 
 // Solve Ax = b in-place (A is F x F, b is length F) via partial-pivot
 // Gaussian elimination. Returns false if singular. Overwrites A and b.
-inline bool gaussianSolve(int F, std::vector<std::vector<double>>& A, std::vector<double>& b) {
-  for(int col = 0; col < F; col++) {
-    int piv = col;
-    for(int r = col + 1; r < F; r++)
-      if(std::fabs(A[r][col]) > std::fabs(A[piv][col])) piv = r;
-    std::swap(A[col], A[piv]);
-    std::swap(b[col], b[piv]);
-    if(std::fabs(A[col][col]) < 1e-12) return false;
-    double inv = 1.0 / A[col][col];
-    for(int r = col + 1; r < F; r++) {
-      double f = A[r][col] * inv;
-      for(int c = col; c < F; c++) A[r][c] -= f * A[col][c];
-      b[r] -= f * b[col];
-    }
-  }
-  for(int r = F - 1; r >= 0; r--) {
-    for(int c = r + 1; c < F; c++) b[r] -= A[r][c] * b[c];
-    b[r] /= A[r][r];
-  }
-  return true;
-}
+bool gaussianSolve(int F, std::vector<std::vector<double>>& A, std::vector<double>& b);
 
 // ============================================================
 // QRSModel: quadratic logistic regression with L2 regularization.
@@ -73,76 +36,20 @@ class QRSModel {
   double l2_;                  // L2 regularization strength
 
  public:
-  QRSModel() : D_(0), F_(0), l2_(0.1) {}
-  QRSModel(int D, double l2_reg = 0.1)
-    : D_(D), F_(numFeatures(D)), beta_(numFeatures(D), 0.0), l2_(l2_reg) {}
+  QRSModel();
+  QRSModel(int D, double l2_reg = 0.1);
 
   // Newton-Raphson MAP estimation.
   // xs: sample coordinates; ys: outcomes in {0.0, 0.5, 1.0}
   void fit(const std::vector<std::vector<double>>& xs,
            const std::vector<double>& ys,
-           int max_iter = 30) {
-    int N = (int)xs.size();
-    if(N < F_) return;  // underdetermined; keep prior beta = 0
-
-    std::vector<double> phi(F_);
-
-    for(int iter = 0; iter < max_iter; iter++) {
-      // Gradient and (negative) Hessian from L2 prior
-      std::vector<double> grad(F_, 0.0);
-      std::vector<std::vector<double>> negH(F_, std::vector<double>(F_, 0.0));
-      for(int f = 0; f < F_; f++) {
-        grad[f] = -l2_ * beta_[f];
-        negH[f][f] = l2_;
-      }
-
-      // Data contribution
-      for(int n = 0; n < N; n++) {
-        computeFeatures(D_, xs[n].data(), phi.data());
-        double z = 0.0;
-        for(int f = 0; f < F_; f++) z += beta_[f] * phi[f];
-        double p = sigmoid(z);
-        double w = p * (1.0 - p);
-        double resid = ys[n] - p;
-        for(int f = 0; f < F_; f++) {
-          grad[f] += resid * phi[f];
-          for(int g = f; g < F_; g++)
-            negH[f][g] += w * phi[f] * phi[g];
-        }
-      }
-      // Symmetrize negH
-      for(int f = 0; f < F_; f++)
-        for(int g = f + 1; g < F_; g++)
-          negH[g][f] = negH[f][g];
-
-      // Solve negH * delta = grad  =>  beta += delta
-      if(!gaussianSolve(F_, negH, grad)) break;
-      double maxd = 0.0;
-      for(int f = 0; f < F_; f++) {
-        beta_[f] += grad[f];
-        maxd = std::max(maxd, std::fabs(grad[f]));
-      }
-      if(maxd < 1e-7) break;
-    }
-  }
+           int max_iter = 30);
 
   // Win probability at x[0..D-1]
-  double predict(const double* x) const {
-    std::vector<double> phi(F_);
-    computeFeatures(D_, x, phi.data());
-    double z = 0.0;
-    for(int f = 0; f < F_; f++) z += beta_[f] * phi[f];
-    return sigmoid(z);
-  }
+  double predict(const double* x) const;
 
   // Linear score phi(x)^T beta (used for MAP maximization)
-  double score(const double* x) const {
-    std::vector<double> phi(F_);
-    computeFeatures(D_, x, phi.data());
-    double z = 0.0;
-    for(int f = 0; f < F_; f++) z += beta_[f] * phi[f];
-    return z;
-  }
+  double score(const double* x) const;
 
   // Find x in [-1,+1]^D that maximizes score(x) = phi(x)^T beta.
   // For a quadratic, the unconstrained stationary point satisfies:
@@ -150,34 +57,7 @@ class QRSModel {
   // where M[i][i] = 2*beta_quad[i], M[i][j]=M[j][i] = beta_cross[i,j],
   //       b_lin[i] = beta_linear[i].
   // The solution is clamped to [-1,+1]^D.
-  void mapOptimum(double* out_x) const {
-    // Beta layout: [intercept, linear[0..D-1], quad[0..D-1], cross by (i<j)]
-    const double* b_lin  = beta_.data() + 1;
-    const double* b_quad = beta_.data() + 1 + D_;
-    const double* b_cross = beta_.data() + 1 + 2 * D_;
-
-    std::vector<std::vector<double>> M(D_, std::vector<double>(D_, 0.0));
-    std::vector<double> rhs(D_);
-
-    for(int k = 0; k < D_; k++) {
-      M[k][k] = 2.0 * b_quad[k];
-      rhs[k]  = -b_lin[k];
-    }
-    int idx = 0;
-    for(int i = 0; i < D_; i++)
-      for(int j = i + 1; j < D_; j++) {
-        M[i][j] += b_cross[idx];
-        M[j][i] += b_cross[idx];
-        idx++;
-      }
-
-    if(!gaussianSolve(D_, M, rhs)) {
-      for(int i = 0; i < D_; i++) out_x[i] = 0.0;
-      return;
-    }
-    for(int i = 0; i < D_; i++)
-      out_x[i] = std::max(-1.0, std::min(1.0, rhs[i]));
-  }
+  void mapOptimum(double* out_x) const;
 
   int dims()     const { return D_; }
   int features() const { return F_; }
@@ -195,60 +75,15 @@ class QRSBuffer {
   double prune_margin_; // drop samples where p_pred < p_best - margin
 
  public:
-  QRSBuffer(int min_keep = 30, double prune_margin = 0.25)
-    : min_keep_(min_keep), prune_margin_(prune_margin) {}
+  QRSBuffer(int min_keep = 30, double prune_margin = 0.25);
 
-  void add(const std::vector<double>& x, double y) {
-    xs_.push_back(x);
-    ys_.push_back(y);
-  }
+  void add(const std::vector<double>& x, double y);
 
   // Remove samples significantly below the current MAP win estimate.
   // Samples are ranked by predicted quality so that min_keep_ retains the
   // best samples rather than the oldest (which are typically from early
   // uniform random exploration).
-  void prune(const QRSModel& model) {
-    int N = (int)xs_.size();
-    if(N <= min_keep_ * 2) return;
-
-    // Score all samples and find best predicted win rate
-    std::vector<std::pair<double, int>> scored(N);
-    double p_best = 0.0;
-    for(int i = 0; i < N; i++) {
-      double p = model.predict(xs_[i].data());
-      scored[i] = {p, i};
-      if(p > p_best) p_best = p;
-    }
-    double threshold = p_best - prune_margin_;
-
-    // Sort by descending predicted quality
-    std::sort(scored.begin(), scored.end(),
-      [](const std::pair<double,int>& a, const std::pair<double,int>& b) {
-        return a.first > b.first;
-      });
-
-    // Keep samples above threshold, plus top-quality samples up to min_keep_
-    std::vector<bool> keep(N, false);
-    int kept = 0;
-    for(auto& kv : scored) {
-      if(kv.first >= threshold || kept < min_keep_) {
-        keep[kv.second] = true;
-        kept++;
-      }
-    }
-
-    // Rebuild in original order to preserve temporal structure
-    std::vector<std::vector<double>> nx;
-    std::vector<double> ny;
-    for(int i = 0; i < N; i++) {
-      if(keep[i]) {
-        nx.push_back(xs_[i]);
-        ny.push_back(ys_[i]);
-      }
-    }
-    xs_ = std::move(nx);
-    ys_ = std::move(ny);
-  }
+  void prune(const QRSModel& model);
 
   const std::vector<std::vector<double>>& xs() const { return xs_; }
   const std::vector<double>&              ys() const { return ys_; }
@@ -292,72 +127,22 @@ class QRSTuner {
            int refit_every   = 10,
            int prune_every   = 5,
            double sigma_init = 0.40,
-           double sigma_fin  = 0.05)
-    : D_(D),
-      model_(D, l2_reg),
-      buffer_(/*min_keep=*/std::max(20, total_trials / 50),
-              /*prune_margin=*/0.25),
-      rng_(seed),
-      trial_count_(0),
-      total_trials_(total_trials),
-      refit_every_(refit_every),
-      prune_every_(prune_every),
-      sigma_initial_(sigma_init),
-      sigma_final_(sigma_fin) {}
+           double sigma_fin  = 0.05);
 
   // Propose next point to evaluate.
   // During early exploration (< F samples) returns a random point.
   // Afterwards: MAP optimum + decaying Gaussian noise clamped to [-1,+1]^D.
-  std::vector<double> nextSample() {
-    std::vector<double> x(D_);
-    int F = model_.features();
-
-    if(buffer_.size() < F + 1) {
-      // Insufficient data for reliable fit — explore uniformly
-      std::uniform_real_distribution<double> uni(-1.0, 1.0);
-      for(int i = 0; i < D_; i++) x[i] = uni(rng_);
-      return x;
-    }
-
-    // Base: MAP optimum
-    model_.mapOptimum(x.data());
-
-    // Decaying exploration noise
-    double progress = (double)trial_count_ / std::max(1, total_trials_ - 1);
-    double sigma = sigma_initial_ + progress * (sigma_final_ - sigma_initial_);
-    std::normal_distribution<double> noise(0.0, sigma);
-    for(int i = 0; i < D_; i++)
-      x[i] = std::max(-1.0, std::min(1.0, x[i] + noise(rng_)));
-
-    return x;
-  }
+  std::vector<double> nextSample();
 
   // Record the outcome of a trial.
   // y: 1.0 = win, 0.0 = loss, 0.5 = draw
-  void addResult(const std::vector<double>& x, double y) {
-    buffer_.add(x, y);
-    trial_count_++;
-
-    if(trial_count_ % refit_every_ == 0 && buffer_.size() >= model_.features() + 1) {
-      model_.fit(buffer_.xs(), buffer_.ys());
-      int refit_count = trial_count_ / refit_every_;
-      if(refit_count % prune_every_ == 0)
-        buffer_.prune(model_);
-    }
-  }
+  void addResult(const std::vector<double>& x, double y);
 
   // Return current MAP optimum in [-1,+1]^D
-  std::vector<double> bestCoords() const {
-    std::vector<double> best(D_);
-    model_.mapOptimum(best.data());
-    return best;
-  }
+  std::vector<double> bestCoords() const;
 
   // Estimated win probability at the MAP optimum
-  double bestWinProb() const {
-    auto best = bestCoords();
-    return model_.predict(best.data());
-  }
+  double bestWinProb() const;
 
   int trialCount()   const { return trial_count_; }
   int dims()         const { return D_; }
@@ -365,3 +150,5 @@ class QRSTuner {
 };
 
 }  // namespace QRSTune
+
+#endif  // QRSTUNE_QRSOPTIMIZER_H_

--- a/cpp/qrstune/QRSOptimizer.h
+++ b/cpp/qrstune/QRSOptimizer.h
@@ -18,12 +18,12 @@ namespace QRSTune {
 //   Total features F = 1 + D + D*(D+1)/2
 // ============================================================
 
-static inline int numFeatures(int D) {
+inline int numFeatures(int D) {
   return 1 + D + D * (D + 1) / 2;
 }
 
 // Fill phi[0..F-1] given x[0..D-1].
-static inline void computeFeatures(int D, const double* x, double* phi) {
+inline void computeFeatures(int D, const double* x, double* phi) {
   int k = 0;
   phi[k++] = 1.0;
   for(int i = 0; i < D; i++) phi[k++] = x[i];
@@ -33,7 +33,7 @@ static inline void computeFeatures(int D, const double* x, double* phi) {
       phi[k++] = x[i] * x[j];
 }
 
-static inline double sigmoid(double z) {
+inline double sigmoid(double z) {
   if(z > 40.0) return 1.0;
   if(z < -40.0) return 0.0;
   return 1.0 / (1.0 + std::exp(-z));
@@ -41,7 +41,7 @@ static inline double sigmoid(double z) {
 
 // Solve Ax = b in-place (A is F x F, b is length F) via partial-pivot
 // Gaussian elimination. Returns false if singular. Overwrites A and b.
-static inline bool gaussianSolve(int F, std::vector<std::vector<double>>& A, std::vector<double>& b) {
+inline bool gaussianSolve(int F, std::vector<std::vector<double>>& A, std::vector<double>& b) {
   for(int col = 0; col < F; col++) {
     int piv = col;
     for(int r = col + 1; r < F; r++)

--- a/cpp/qrstune/QRSOptimizer.h
+++ b/cpp/qrstune/QRSOptimizer.h
@@ -149,6 +149,8 @@ class QRSTuner {
   const QRSModel& model() const { return model_; }
 };
 
+void runTests();
+
 }  // namespace QRSTune
 
 #endif  // QRSTUNE_QRSOPTIMIZER_H_

--- a/cpp/qrstune/QRSOptimizer.h
+++ b/cpp/qrstune/QRSOptimizer.h
@@ -1,0 +1,346 @@
+// qrstune/QRSOptimizer.h
+
+#pragma once
+
+#include <vector>
+#include <cmath>
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <random>
+#include <stdexcept>
+
+namespace QRSTune {
+
+// ============================================================
+// Feature map phi(x):
+//   [1,  x_0..x_{D-1},  x_0^2..x_{D-1}^2,  x_i*x_j for i<j]
+//   Total features F = 1 + D + D*(D+1)/2
+// ============================================================
+
+static inline int numFeatures(int D) {
+  return 1 + D + D * (D + 1) / 2;
+}
+
+// Fill phi[0..F-1] given x[0..D-1].
+static inline void computeFeatures(int D, const double* x, double* phi) {
+  int k = 0;
+  phi[k++] = 1.0;
+  for(int i = 0; i < D; i++) phi[k++] = x[i];
+  for(int i = 0; i < D; i++) phi[k++] = x[i] * x[i];
+  for(int i = 0; i < D; i++)
+    for(int j = i + 1; j < D; j++)
+      phi[k++] = x[i] * x[j];
+}
+
+static inline double sigmoid(double z) {
+  if(z > 40.0) return 1.0;
+  if(z < -40.0) return 0.0;
+  return 1.0 / (1.0 + std::exp(-z));
+}
+
+// Solve Ax = b in-place (A is F x F, b is length F) via partial-pivot
+// Gaussian elimination. Returns false if singular. Overwrites A and b.
+static bool gaussianSolve(int F, std::vector<std::vector<double>>& A, std::vector<double>& b) {
+  for(int col = 0; col < F; col++) {
+    int piv = col;
+    for(int r = col + 1; r < F; r++)
+      if(std::fabs(A[r][col]) > std::fabs(A[piv][col])) piv = r;
+    std::swap(A[col], A[piv]);
+    std::swap(b[col], b[piv]);
+    if(std::fabs(A[col][col]) < 1e-12) return false;
+    double inv = 1.0 / A[col][col];
+    for(int r = col + 1; r < F; r++) {
+      double f = A[r][col] * inv;
+      for(int c = col; c < F; c++) A[r][c] -= f * A[col][c];
+      b[r] -= f * b[col];
+    }
+  }
+  for(int r = F - 1; r >= 0; r--) {
+    for(int c = r + 1; c < F; c++) b[r] -= A[r][c] * b[c];
+    b[r] /= A[r][r];
+  }
+  return true;
+}
+
+// ============================================================
+// QRSModel: quadratic logistic regression with L2 regularization.
+// Provides MAP estimation and win-probability prediction.
+// ============================================================
+class QRSModel {
+  int D_, F_;
+  std::vector<double> beta_;   // F coefficients (intercept, linear, quad, cross)
+  double l2_;                  // L2 regularization strength
+
+ public:
+  QRSModel() : D_(0), F_(0), l2_(0.1) {}
+  QRSModel(int D, double l2_reg = 0.1)
+    : D_(D), F_(numFeatures(D)), beta_(numFeatures(D), 0.0), l2_(l2_reg) {}
+
+  // Newton-Raphson MAP estimation.
+  // xs: sample coordinates; ys: outcomes in {0.0, 0.5, 1.0}
+  void fit(const std::vector<std::vector<double>>& xs,
+           const std::vector<double>& ys,
+           int max_iter = 30) {
+    int N = (int)xs.size();
+    if(N < F_) return;  // underdetermined; keep prior beta = 0
+
+    std::vector<double> phi(F_);
+
+    for(int iter = 0; iter < max_iter; iter++) {
+      // Gradient and (negative) Hessian from L2 prior
+      std::vector<double> grad(F_, 0.0);
+      std::vector<std::vector<double>> negH(F_, std::vector<double>(F_, 0.0));
+      for(int f = 0; f < F_; f++) {
+        grad[f] = -l2_ * beta_[f];
+        negH[f][f] = l2_;
+      }
+
+      // Data contribution
+      for(int n = 0; n < N; n++) {
+        computeFeatures(D_, xs[n].data(), phi.data());
+        double z = 0.0;
+        for(int f = 0; f < F_; f++) z += beta_[f] * phi[f];
+        double p = sigmoid(z);
+        double w = p * (1.0 - p);
+        double resid = ys[n] - p;
+        for(int f = 0; f < F_; f++) {
+          grad[f] += resid * phi[f];
+          for(int g = f; g < F_; g++)
+            negH[f][g] += w * phi[f] * phi[g];
+        }
+      }
+      // Symmetrize negH
+      for(int f = 0; f < F_; f++)
+        for(int g = f + 1; g < F_; g++)
+          negH[g][f] = negH[f][g];
+
+      // Solve negH * delta = grad  =>  beta += delta
+      if(!gaussianSolve(F_, negH, grad)) break;
+      double maxd = 0.0;
+      for(int f = 0; f < F_; f++) {
+        beta_[f] += grad[f];
+        maxd = std::max(maxd, std::fabs(grad[f]));
+      }
+      if(maxd < 1e-7) break;
+    }
+  }
+
+  // Win probability at x[0..D-1]
+  double predict(const double* x) const {
+    std::vector<double> phi(F_);
+    computeFeatures(D_, x, phi.data());
+    double z = 0.0;
+    for(int f = 0; f < F_; f++) z += beta_[f] * phi[f];
+    return sigmoid(z);
+  }
+
+  // Linear score phi(x)^T beta (used for MAP maximization)
+  double score(const double* x) const {
+    std::vector<double> phi(F_);
+    computeFeatures(D_, x, phi.data());
+    double z = 0.0;
+    for(int f = 0; f < F_; f++) z += beta_[f] * phi[f];
+    return z;
+  }
+
+  // Find x in [-1,+1]^D that maximizes score(x) = phi(x)^T beta.
+  // For a quadratic, the unconstrained stationary point satisfies:
+  //   M x = -b_lin
+  // where M[i][i] = 2*beta_quad[i], M[i][j]=M[j][i] = beta_cross[i,j],
+  //       b_lin[i] = beta_linear[i].
+  // The solution is clamped to [-1,+1]^D.
+  void mapOptimum(double* out_x) const {
+    // Beta layout: [intercept, linear[0..D-1], quad[0..D-1], cross by (i<j)]
+    const double* b_lin  = beta_.data() + 1;
+    const double* b_quad = beta_.data() + 1 + D_;
+    const double* b_cross = beta_.data() + 1 + 2 * D_;
+
+    std::vector<std::vector<double>> M(D_, std::vector<double>(D_, 0.0));
+    std::vector<double> rhs(D_);
+
+    for(int k = 0; k < D_; k++) {
+      M[k][k] = 2.0 * b_quad[k];
+      rhs[k]  = -b_lin[k];
+    }
+    int idx = 0;
+    for(int i = 0; i < D_; i++)
+      for(int j = i + 1; j < D_; j++) {
+        M[i][j] += b_cross[idx];
+        M[j][i] += b_cross[idx];
+        idx++;
+      }
+
+    if(!gaussianSolve(D_, M, rhs)) {
+      for(int i = 0; i < D_; i++) out_x[i] = 0.0;
+      return;
+    }
+    for(int i = 0; i < D_; i++)
+      out_x[i] = std::max(-1.0, std::min(1.0, rhs[i]));
+  }
+
+  int dims()     const { return D_; }
+  int features() const { return F_; }
+};
+
+// ============================================================
+// QRSBuffer: sample storage with confidence-based pruning.
+// Samples whose predicted win rate is far below the current
+// MAP estimate are dropped to keep the model locally focused.
+// ============================================================
+class QRSBuffer {
+  std::vector<std::vector<double>> xs_;
+  std::vector<double> ys_;
+  int min_keep_;        // never prune below this count
+  double prune_margin_; // drop samples where p_pred < p_best - margin
+
+ public:
+  QRSBuffer(int min_keep = 30, double prune_margin = 0.25)
+    : min_keep_(min_keep), prune_margin_(prune_margin) {}
+
+  void add(const std::vector<double>& x, double y) {
+    xs_.push_back(x);
+    ys_.push_back(y);
+  }
+
+  // Remove samples significantly below the current MAP win estimate.
+  void prune(const QRSModel& model) {
+    int N = (int)xs_.size();
+    if(N <= min_keep_ * 2) return;
+
+    // Best predicted win rate across all stored samples
+    double p_best = 0.0;
+    for(int i = 0; i < N; i++) {
+      double p = model.predict(xs_[i].data());
+      if(p > p_best) p_best = p;
+    }
+    double threshold = p_best - prune_margin_;
+
+    std::vector<std::vector<double>> nx;
+    std::vector<double> ny;
+    for(int i = 0; i < N; i++) {
+      double p = model.predict(xs_[i].data());
+      if(p >= threshold || (int)nx.size() < min_keep_) {
+        nx.push_back(xs_[i]);
+        ny.push_back(ys_[i]);
+      }
+    }
+    xs_ = std::move(nx);
+    ys_ = std::move(ny);
+  }
+
+  const std::vector<std::vector<double>>& xs() const { return xs_; }
+  const std::vector<double>&              ys() const { return ys_; }
+  int size() const { return (int)xs_.size(); }
+};
+
+// ============================================================
+// QRSTuner: top-level interface
+//
+// Usage:
+//   QRSTuner tuner(D, seed, numTrials);
+//   for each trial:
+//     auto x = tuner.nextSample();
+//     ... run game, get win=1.0 / loss=0.0 / draw=0.5 ...
+//     tuner.addResult(x, outcome);
+//   auto best = tuner.bestCoords();
+// ============================================================
+class QRSTuner {
+  int D_;
+  QRSModel  model_;
+  QRSBuffer buffer_;
+  std::mt19937_64 rng_;
+  int trial_count_;
+  int total_trials_;
+  int refit_every_;    // refit model after every N trials
+  int prune_every_;    // prune once per this many refits
+
+  // Exploration noise std dev: decays linearly from initial to final
+  double sigma_initial_;
+  double sigma_final_;
+
+ public:
+  // D            : number of dimensions
+  // seed         : RNG seed for reproducibility
+  // total_trials : expected total number of trials (for scheduling)
+  // l2_reg       : L2 regularization for QRSModel (default 0.1)
+  // refit_every  : how often to refit model (default 10 trials)
+  // prune_every  : prune every N-th refit (default 5)
+  QRSTuner(int D, uint64_t seed, int total_trials,
+           double l2_reg     = 0.1,
+           int refit_every   = 10,
+           int prune_every   = 5,
+           double sigma_init = 0.40,
+           double sigma_fin  = 0.05)
+    : D_(D),
+      model_(D, l2_reg),
+      buffer_(/*min_keep=*/std::max(20, total_trials / 50),
+              /*prune_margin=*/0.25),
+      rng_(seed),
+      trial_count_(0),
+      total_trials_(total_trials),
+      refit_every_(refit_every),
+      prune_every_(prune_every),
+      sigma_initial_(sigma_init),
+      sigma_final_(sigma_fin) {}
+
+  // Propose next point to evaluate.
+  // During early exploration (< F samples) returns a random point.
+  // Afterwards: MAP optimum + decaying Gaussian noise clamped to [-1,+1]^D.
+  std::vector<double> nextSample() {
+    std::vector<double> x(D_);
+    int F = model_.features();
+
+    if(buffer_.size() < F + 1) {
+      // Insufficient data for reliable fit — explore uniformly
+      std::uniform_real_distribution<double> uni(-1.0, 1.0);
+      for(int i = 0; i < D_; i++) x[i] = uni(rng_);
+      return x;
+    }
+
+    // Base: MAP optimum
+    model_.mapOptimum(x.data());
+
+    // Decaying exploration noise
+    double progress = (double)trial_count_ / std::max(1, total_trials_ - 1);
+    double sigma = sigma_initial_ + progress * (sigma_final_ - sigma_initial_);
+    std::normal_distribution<double> noise(0.0, sigma);
+    for(int i = 0; i < D_; i++)
+      x[i] = std::max(-1.0, std::min(1.0, x[i] + noise(rng_)));
+
+    return x;
+  }
+
+  // Record the outcome of a trial.
+  // y: 1.0 = win, 0.0 = loss, 0.5 = draw
+  void addResult(const std::vector<double>& x, double y) {
+    buffer_.add(x, y);
+    trial_count_++;
+
+    if(trial_count_ % refit_every_ == 0 && buffer_.size() >= model_.features() + 1) {
+      model_.fit(buffer_.xs(), buffer_.ys());
+      int refit_count = trial_count_ / refit_every_;
+      if(refit_count % prune_every_ == 0)
+        buffer_.prune(model_);
+    }
+  }
+
+  // Return current MAP optimum in [-1,+1]^D
+  std::vector<double> bestCoords() const {
+    std::vector<double> best(D_);
+    model_.mapOptimum(best.data());
+    return best;
+  }
+
+  // Estimated win probability at the MAP optimum
+  double bestWinProb() const {
+    auto best = bestCoords();
+    return model_.predict(best.data());
+  }
+
+  int trialCount()   const { return trial_count_; }
+  int dims()         const { return D_; }
+  const QRSModel& model() const { return model_; }
+};
+
+}  // namespace QRSTune


### PR DESCRIPTION
## Summary

Add a `tune-params` subcommand for sequential optimization of KataGo's `cpuctExploration` PUCT parameter using QRS-Tune (Quadratic Response Surface), and add post-match statistical analysis to the existing `match` command.

### `tune-params` subcommand
- Optimizes a single PUCT parameter: `cpuctExploration` in linear range [0.5, 1.5] (configurable via `cpuctExplorationMin` / `cpuctExplorationMax`).
- QRS-Tune: quadratic response-surface optimizer with logistic regression, adaptive sampling (uniform while the model is non-concave, Gaussian around the predicted optimum once concave), and confidence-based sample pruning.
- Runs a fixed reference bot (bot0) vs. an experiment bot (bot1) for `numTrials` games, alternating colors to remove first-move bias.
- Reports best value with 95% CI (delta-method), concavity flag, and an ASCII regression curve.
- Prints a ready-to-run `./katago match` verification command with the tuned value baked in.
- Graceful shutdown on SIGINT/SIGTERM.
- Unit/convergence tests for QRSOptimizer at 100 / 1000 / 10000 trials, including a flat-landscape (low-curvature) test case.

### `match` statistics
- Bradley-Terry Elo ratings via Newton-Raphson, with per-bot standard errors and a convergence warning if iteration limit is hit.
- Wilson 95% confidence intervals for per-bot win rates.
- Pairwise W/L/D summaries with likelihood-ratio p-values.

### Empirical validation
Tuning run on 19x19, `lionffen_b6c64_3x3_v10`, 1000 trials × 4000 visits, 16 search threads:

- **Best `cpuctExploration` = 1.2441**, 95% CI [1.1240, 1.3643]
- Record: 472W / 436L / 92D, estimated winrate 0.537 vs. reference
- Final model: concave, `quadDiag = -1.087`, `bestQRS = 0.488` (optimum well inside range)
- Suggested verification command auto-printed at end of run.

### New files
- `cpp/qrstune/QRSOptimizer.h` / `QRSOptimizer.cpp` — QRS-Tune optimizer (quadratic feature map, logistic regression, Gaussian elimination, confidence-based pruning, convergence tests).
- `cpp/command/tuneparams.cpp` — `tune-params` subcommand.
- `cpp/configs/tune_params_example.cfg` — example config.

### Modified files
- `cpp/CMakeLists.txt` — build registration.
- `cpp/main.h` / `cpp/main.cpp` — subcommand dispatch.
- `cpp/command/match.cpp` — Elo / CI / p-value output after matches.
- `.gitignore` — ignore root-level `build/`.

## Test plan
- [x] `./katago runtests`
- [x] `./katago testgpuerror`
- [x] `./katago tune-params -config configs/tune_params_example.cfg` — 1000 trials on 19x19 complete without errors; optimum sits within configured range.
- [ ] Run the auto-suggested verification match (tuned vs. default) to confirm winrate gain reproduces.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)