### PR TITLE
Precompile built-in + human SL aux at app launch when cache is empty

### DIFF
--- a/docs/superpowers/plans/2026-05-12-precompile-cache-empty-sweep.md
+++ b/docs/superpowers/plans/2026-05-12-precompile-cache-empty-sweep.md
@@ -1,0 +1,551 @@
+# Precompile Cache-Empty Sweep Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-precompile the built-in network and the bundled human SL aux network at app launch whenever the Core ML cache lacks their entries — independent of the bundle-version rewarm trigger.
+
+**Architecture:** Add a `runCacheEmptySweep` helper that runs in `KataGo_iOSApp.swift`'s `.task` blocks immediately after `scheduler.hydrate(...)`. For each of `{built-in, aux}`, if `scheduler.status[fileName] != .ready`, call `scheduler.scheduleForModel(fileName:)`. Extend `makeProjectionResolver` to map the aux fileName to bundle-resourced inputs derived from the built-in's `BackendSettings`. Extend `scheduleForModel`'s mpsGPU skip so the aux inherits its skip decision from the built-in's persisted backend key. Bundle-version rewarm in `ModelRunnerView.onAppear` stays unchanged.
+
+**Tech Stack:** Swift 6, SwiftUI, Swift Testing (`Testing` import), Xcode 16, `xcodebuild` from CLI.
+
+**Spec:** `docs/superpowers/specs/2026-05-12-precompile-cache-empty-sweep-design.md`
+
+**Conventions used by this codebase (read once):**
+- Test target imports use `@testable import KataGo_Anytime` (space → underscore).
+- Swift Testing style: `@Test func name() async throws { ... }`, `#expect(...)`.
+- Per-test `UserDefaults` isolation pattern: `UserDefaults(suiteName: "test.\(UUID())")!` (see `PrecompileSchedulerTests.skipsWhenBackendIsMpsGpu`).
+- Aux fileName constant: `"b18c384nbt-humanv0.bin.gz"` (also bundled as resource `b18c384nbt-humanv0.bin.gz`).
+- Built-in fileName constant: `"default_model.bin.gz"`.
+
+---
+
+## File Structure
+
+**Modify:**
+- `ios/KataGo iOS/KataGo iOS/PrecompileProjection.swift` — add aux fileName special-case in `makeProjectionResolver`.
+- `ios/KataGo iOS/KataGo iOS/PrecompileScheduler.swift` — extend mpsGPU skip logic in `scheduleForModel` to inherit from built-in when fileName is the aux.
+- `ios/KataGo iOS/KataGo iOS/KataGo_iOSApp.swift` — add `runCacheEmptySweep` free function; extend `knownFileNames` and call sweep in both `.task` branches (iOS/visionOS and macOS).
+- `ios/KataGo iOS/KataGo iOSTests/PrecompileProjectionTests.swift` — add aux resolver test.
+- `ios/KataGo iOS/KataGo iOSTests/PrecompileSchedulerTests.swift` — add aux mpsGPU inheritance test.
+
+**Create:**
+- `ios/KataGo iOS/KataGo iOSTests/AppLaunchPrecompileSweepTests.swift` — sweep helper tests.
+
+---
+
+## Task 1: Aux projection in `makeProjectionResolver`
+
+**Files:**
+- Modify: `ios/KataGo iOS/KataGo iOS/PrecompileProjection.swift`
+- Test: `ios/KataGo iOS/KataGo iOSTests/PrecompileProjectionTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `KataGo iOSTests/PrecompileProjectionTests.swift` (inside the existing `struct PrecompileProjectionTests`):
+
+```swift
+    @Test func resolverReturnsInputsForHumanSLAux() async throws {
+        let inputs = makeProjectionResolver()("b18c384nbt-humanv0.bin.gz")
+        #expect(inputs != nil)
+        guard let inputs else { return }
+        #expect(inputs.sourcePath.hasSuffix("b18c384nbt-humanv0.bin.gz"))
+        #expect(inputs.nnXLen > 0)
+        #expect(inputs.nnYLen > 0)
+        #expect(inputs.nnXLen == inputs.nnYLen)
+        #expect(inputs.useFP16 == true)
+        #expect(inputs.maxBatchSize == 1)
+
+        // Aux projection must mirror the built-in's settings: same nnLen
+        // and same requireExactNNLen so the cache key matches what the
+        // engine launch will compute when the built-in is selected.
+        let builtIn = makeProjectionResolver()("default_model.bin.gz")
+        #expect(builtIn != nil)
+        if let builtIn {
+            #expect(inputs.nnXLen == builtIn.nnXLen)
+            #expect(inputs.nnYLen == builtIn.nnYLen)
+            #expect(inputs.requireExactNNLen == builtIn.requireExactNNLen)
+        }
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+xcodebuild test -project "ios/KataGo iOS/KataGo Anytime.xcodeproj" \
+  -scheme "KataGo Anytime" \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:"KataGo AnytimeTests/PrecompileProjectionTests/resolverReturnsInputsForHumanSLAux"
+```
+Expected: FAIL with `inputs != nil` failed expectation (the current resolver returns `nil` for any fileName not in `NeuralNetworkModel.allCases`).
+
+- [ ] **Step 3: Implement the resolver extension**
+
+In `ios/KataGo iOS/KataGo iOS/PrecompileProjection.swift`, replace the body of `makeProjectionResolver()`:
+
+```swift
+func makeProjectionResolver() -> ProjectionResolver {
+    return { fileName in
+        // Human SL aux is bundled and shares the built-in's backend
+        // settings (the engine loads them together with the same nnLen
+        // and same fp16/maxBatchSize). Project its digest against the
+        // built-in's settings so the precompiled aux is reused verbatim
+        // when the user selects the built-in.
+        if fileName == "b18c384nbt-humanv0.bin.gz" {
+            guard let bundlePath = Bundle.main.path(
+                    forResource: "b18c384nbt-humanv0",
+                    ofType: "bin.gz"),
+                  let builtIn = NeuralNetworkModel.builtInModel
+            else { return nil }
+            let settings = BackendSettings(model: builtIn)
+            let nnLen = Int32(settings.effectiveMaxBoardLength)
+            return ProjectionInputs(
+                sourcePath: bundlePath,
+                nnXLen: nnLen,
+                nnYLen: nnLen,
+                requireExactNNLen: settings.requireExactNNLen,
+                useFP16: true,
+                maxBatchSize: 1)
+        }
+
+        guard let model = NeuralNetworkModel.allCases.first(where: { $0.fileName == fileName })
+        else { return nil }
+
+        let sourcePath: String
+        if model.builtIn {
+            guard let bundlePath = Bundle.main.path(
+                forResource: "default_model",
+                ofType: "bin.gz")
+            else { return nil }
+            sourcePath = bundlePath
+        } else {
+            guard let downloaded = model.downloadedURL,
+                  FileManager.default.fileExists(atPath: downloaded.path)
+            else { return nil }
+            sourcePath = downloaded.path
+        }
+
+        let settings = BackendSettings(model: model)
+        let nnLen = Int32(settings.effectiveMaxBoardLength)
+        return ProjectionInputs(
+            sourcePath: sourcePath,
+            nnXLen: nnLen,
+            nnYLen: nnLen,
+            requireExactNNLen: settings.requireExactNNLen,
+            useFP16: true,
+            maxBatchSize: 1)
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+xcodebuild test -project "ios/KataGo iOS/KataGo Anytime.xcodeproj" \
+  -scheme "KataGo Anytime" \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:"KataGo AnytimeTests/PrecompileProjectionTests"
+```
+Expected: All `PrecompileProjectionTests` cases PASS (`resolverReturnsNilForUnknownFileName`, `resolverReturnsInputsForBuiltInModel`, and the new `resolverReturnsInputsForHumanSLAux`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "ios/KataGo iOS/KataGo iOS/PrecompileProjection.swift" \
+        "ios/KataGo iOS/KataGo iOSTests/PrecompileProjectionTests.swift"
+git commit -m "feat: project human SL aux digest against built-in's settings"
+```
+
+---
+
+## Task 2: Aux mpsGPU skip inherits from built-in
+
+**Files:**
+- Modify: `ios/KataGo iOS/KataGo iOS/PrecompileScheduler.swift:73-78`
+- Test: `ios/KataGo iOS/KataGo iOSTests/PrecompileSchedulerTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `KataGo iOSTests/PrecompileSchedulerTests.swift` (inside `struct PrecompileSchedulerTests`):
+
+```swift
+    @Test func skipsAuxWhenBuiltInBackendIsMpsGpu() async throws {
+        let defaults = UserDefaults(suiteName: "test.\(UUID())")!
+        defaults.set("mpsGPU", forKey: "backend_default_model.bin.gz")
+
+        actor Counter { var n = 0; func inc() { n += 1 }; func get() -> Int { n } }
+        let counter = Counter()
+        let scheduler = await PrecompileScheduler(defaults: defaults) { _ in
+            await counter.inc()
+        }
+        await scheduler.scheduleForModel(fileName: "b18c384nbt-humanv0.bin.gz")
+
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await counter.get() == 0)
+    }
+
+    @Test func runsAuxWhenBuiltInBackendIsCoreml() async throws {
+        let defaults = UserDefaults(suiteName: "test.\(UUID())")!
+        defaults.set("coremlNE", forKey: "backend_default_model.bin.gz")
+
+        actor Counter { var n = 0; func inc() { n += 1 }; func get() -> Int { n } }
+        let counter = Counter()
+        let scheduler = await PrecompileScheduler(defaults: defaults) { _ in
+            await counter.inc()
+        }
+        await scheduler.scheduleForModel(fileName: "b18c384nbt-humanv0.bin.gz")
+
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await counter.get() == 1)
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+xcodebuild test -project "ios/KataGo iOS/KataGo Anytime.xcodeproj" \
+  -scheme "KataGo Anytime" \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:"KataGo AnytimeTests/PrecompileSchedulerTests/skipsAuxWhenBuiltInBackendIsMpsGpu" \
+  -only-testing:"KataGo AnytimeTests/PrecompileSchedulerTests/runsAuxWhenBuiltInBackendIsCoreml"
+```
+Expected: `skipsAuxWhenBuiltInBackendIsMpsGpu` FAILS (`counter.get() == 0` expectation fails — the current code reads `backend_b18c384nbt-humanv0.bin.gz`, which is unset, so the worker runs). `runsAuxWhenBuiltInBackendIsCoreml` may PASS already (it's the no-skip case) — that's fine, it's a regression guard.
+
+- [ ] **Step 3: Implement the skip-key resolution**
+
+In `ios/KataGo iOS/KataGo iOS/PrecompileScheduler.swift`, replace the first lines of `scheduleForModel(fileName:)`:
+
+```swift
+    public func scheduleForModel(fileName: String) async {
+        // Aux's projection borrows the built-in's BackendSettings, so its
+        // mpsGPU-vs-CoreML skip decision must also follow the built-in.
+        // The aux's own `backend_<aux>` key is never written by any UI
+        // surface, so reading it would always be nil and the aux would
+        // never be skipped — which would diverge from the projection.
+        let backendKey: String = (fileName == "b18c384nbt-humanv0.bin.gz")
+            ? "backend_default_model.bin.gz"
+            : "backend_\(fileName)"
+        if defaults.string(forKey: backendKey) == "mpsGPU" {
+            log.info("skip-precompile reason=mpsGPU fileName=\(fileName, privacy: .public)")
+            return
+        }
+        guard !inFlight.contains(fileName) else { return }
+        inFlight.insert(fileName)
+        ephemeral[fileName] = .queued
+        Task(priority: .utility) {
+            self.ephemeral[fileName] = .compiling
+            do {
+                try await self.worker(fileName)
+                self.ephemeral[fileName] = nil
+                await self.refreshCachedReady(for: fileName)
+            } catch {
+                let summary = (error as NSError).localizedDescription
+                log.error("precompile.failed model=\(fileName, privacy: .public) error=\(String(describing: error), privacy: .public)")
+                self.ephemeral[fileName] = .failed(message: summary)
+            }
+            self.inFlight.remove(fileName)
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+xcodebuild test -project "ios/KataGo iOS/KataGo Anytime.xcodeproj" \
+  -scheme "KataGo Anytime" \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:"KataGo AnytimeTests/PrecompileSchedulerTests"
+```
+Expected: All `PrecompileSchedulerTests` cases PASS, including both new aux cases and the existing built-in mpsGPU / coremlNE cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "ios/KataGo iOS/KataGo iOS/PrecompileScheduler.swift" \
+        "ios/KataGo iOS/KataGo iOSTests/PrecompileSchedulerTests.swift"
+git commit -m "feat: human SL aux inherits built-in's mpsGPU skip decision"
+```
+
+---
+
+## Task 3: `runCacheEmptySweep` helper
+
+**Files:**
+- Modify: `ios/KataGo iOS/KataGo iOS/KataGo_iOSApp.swift`
+- Create: `ios/KataGo iOS/KataGo iOSTests/AppLaunchPrecompileSweepTests.swift`
+
+- [ ] **Step 1: Write the failing tests (file)**
+
+Create `ios/KataGo iOS/KataGo iOSTests/AppLaunchPrecompileSweepTests.swift` with:
+
+```swift
+import Foundation
+import Testing
+import KataGoInterface
+@testable import KataGo_Anytime
+
+struct AppLaunchPrecompileSweepTests {
+
+    // Shared fixture: scheduler whose worker only counts invocations
+    // per fileName. Backend keys are left unset in the per-test
+    // UserDefaults suite so the mpsGPU skip never fires.
+    private func makeFixture() async -> (PrecompileScheduler, FileNameCounter) {
+        let defaults = UserDefaults(suiteName: "test.\(UUID())")!
+        let counter = FileNameCounter()
+        let scheduler = await PrecompileScheduler(defaults: defaults) { fileName in
+            await counter.inc(fileName)
+        }
+        return (scheduler, counter)
+    }
+
+    actor FileNameCounter {
+        private var counts: [String: Int] = [:]
+        func inc(_ fileName: String) { counts[fileName, default: 0] += 1 }
+        func count(_ fileName: String) -> Int { counts[fileName] ?? 0 }
+        func total() -> Int { counts.values.reduce(0, +) }
+    }
+
+    @MainActor
+    @Test func sweepsBothWhenCacheEmpty() async throws {
+        let (scheduler, counter) = await makeFixture()
+        // status is empty -> both targets are not .ready.
+
+        await runCacheEmptySweep(scheduler: scheduler)
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(await counter.count("default_model.bin.gz") == 1)
+        #expect(await counter.count("b18c384nbt-humanv0.bin.gz") == 1)
+        #expect(await counter.total() == 2)
+    }
+
+    @MainActor
+    @Test func sweepsOnlyAuxWhenBuiltInReady() async throws {
+        let (scheduler, counter) = await makeFixture()
+        scheduler._setCachedReadyForTests(["default_model.bin.gz"])
+
+        await runCacheEmptySweep(scheduler: scheduler)
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(await counter.count("default_model.bin.gz") == 0)
+        #expect(await counter.count("b18c384nbt-humanv0.bin.gz") == 1)
+    }
+
+    @MainActor
+    @Test func sweepsNothingWhenBothReady() async throws {
+        let (scheduler, counter) = await makeFixture()
+        scheduler._setCachedReadyForTests([
+            "default_model.bin.gz",
+            "b18c384nbt-humanv0.bin.gz"
+        ])
+
+        await runCacheEmptySweep(scheduler: scheduler)
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(await counter.total() == 0)
+    }
+
+    @MainActor
+    @Test func sweepDoesNotReScheduleQueuedOrCompiling() async throws {
+        let (scheduler, counter) = await makeFixture()
+        scheduler._setEphemeralForTests([
+            "default_model.bin.gz": .compiling,
+            "b18c384nbt-humanv0.bin.gz": .queued
+        ])
+
+        await runCacheEmptySweep(scheduler: scheduler)
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Neither target is .ready, but both are in-flight. The sweep
+        // calls scheduleForModel anyway; scheduleForModel's inFlight
+        // dedup is what blocks the worker from being invoked again.
+        // What we assert here is the user-visible outcome: the worker
+        // is not run a second time.
+        #expect(await counter.count("default_model.bin.gz") == 0)
+        #expect(await counter.count("b18c384nbt-humanv0.bin.gz") == 0)
+    }
+}
+```
+
+- [ ] **Step 2: Add the new test file to the Xcode test target**
+
+The test bundle must include the new file. Open `KataGo Anytime.xcodeproj` in Xcode and add `KataGo iOSTests/AppLaunchPrecompileSweepTests.swift` to the `KataGo AnytimeTests` target (drag the file into the test group, or use **File → Add Files to "KataGo Anytime"…** with the test target checked). Save the project.
+
+If working without the Xcode UI, edit `ios/KataGo iOS/KataGo Anytime.xcodeproj/project.pbxproj` to register the file under the test target (mirror an existing test file's `PBXFileReference` + `PBXBuildFile` + `PBXSourcesBuildPhase` entries, e.g. `PrecompileSchedulerTests.swift`).
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+```bash
+xcodebuild test -project "ios/KataGo iOS/KataGo Anytime.xcodeproj" \
+  -scheme "KataGo Anytime" \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:"KataGo AnytimeTests/AppLaunchPrecompileSweepTests"
+```
+Expected: BUILD FAILURE — `runCacheEmptySweep` is undefined.
+
+- [ ] **Step 4: Implement the helper**
+
+In `ios/KataGo iOS/KataGo iOS/KataGo_iOSApp.swift`, add this free function near the top of the file (after the imports, before `@main struct KataGo_iOSApp`):
+
+```swift
+/// File names auto-warmed at app launch when their cache entry is
+/// missing. Built-in + bundled human SL aux only — downloaded mains
+/// are handled by `ModelPickerView.downloader.onDownloadComplete`.
+private let autoWarmFileNames: [String] = [
+    "default_model.bin.gz",
+    "b18c384nbt-humanv0.bin.gz"
+]
+
+/// Cache-empty sweep. For each auto-warm target whose status is not
+/// `.ready`, enqueue a precompile. Runs after `scheduler.hydrate(...)`
+/// in the app's scene `.task`. `scheduleForModel`'s `inFlight` dedup
+/// makes repeated calls (e.g. scene reactivation) cheap, and the
+/// bundle-version rewarm in `ModelRunnerView.onAppear` cooperates via
+/// the same dedup path.
+@MainActor
+func runCacheEmptySweep(scheduler: PrecompileScheduler) async {
+    for fileName in autoWarmFileNames {
+        if scheduler.status[fileName] != .ready {
+            await scheduler.scheduleForModel(fileName: fileName)
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+```bash
+xcodebuild test -project "ios/KataGo iOS/KataGo Anytime.xcodeproj" \
+  -scheme "KataGo Anytime" \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:"KataGo AnytimeTests/AppLaunchPrecompileSweepTests"
+```
+Expected: All four `AppLaunchPrecompileSweepTests` cases PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "ios/KataGo iOS/KataGo iOS/KataGo_iOSApp.swift" \
+        "ios/KataGo iOS/KataGo iOSTests/AppLaunchPrecompileSweepTests.swift" \
+        "ios/KataGo iOS/KataGo Anytime.xcodeproj/project.pbxproj"
+git commit -m "feat: add runCacheEmptySweep helper for built-in + aux"
+```
+
+---
+
+## Task 4: Wire sweep into app launch + extend `knownFileNames`
+
+**Files:**
+- Modify: `ios/KataGo iOS/KataGo iOS/KataGo_iOSApp.swift:60-90`
+
+- [ ] **Step 1: Update both `.task` branches**
+
+In `ios/KataGo iOS/KataGo iOS/KataGo_iOSApp.swift`, replace the macOS `.task` block (around lines 59–71):
+
+```swift
+                    .task {
+                        let knownFileNames = Set(NeuralNetworkModel.allCases.map(\.fileName))
+                            .union(autoWarmFileNames)
+                        let digestFor = makeProjectionDigestFor()
+                        await CoreMLModelCache.shared.start()
+                        await precompileScheduler.hydrate(
+                            from: .shared,
+                            fileNames: knownFileNames,
+                            digestFor: digestFor)
+                        await precompileScheduler.subscribeToCacheEvents(
+                            .shared,
+                            fileNames: knownFileNames,
+                            digestFor: digestFor)
+                        await runCacheEmptySweep(scheduler: precompileScheduler)
+                    }
+```
+
+And the iOS/visionOS `.task` block (around lines 78–90):
+
+```swift
+                    .task {
+                        let knownFileNames = Set(NeuralNetworkModel.allCases.map(\.fileName))
+                            .union(autoWarmFileNames)
+                        let digestFor = makeProjectionDigestFor()
+                        await CoreMLModelCache.shared.start()
+                        await precompileScheduler.hydrate(
+                            from: .shared,
+                            fileNames: knownFileNames,
+                            digestFor: digestFor)
+                        await precompileScheduler.subscribeToCacheEvents(
+                            .shared,
+                            fileNames: knownFileNames,
+                            digestFor: digestFor)
+                        await runCacheEmptySweep(scheduler: precompileScheduler)
+                    }
+```
+
+(`autoWarmFileNames` was declared as a `Set` of two — `.union(autoWarmFileNames)` here uses it as a `Sequence`, which works for `[String]`. The set union dedupes the `default_model.bin.gz` entry that `allCases` already provides.)
+
+- [ ] **Step 2: Build for all three platforms**
+
+Run:
+```bash
+xcodebuild build -project "ios/KataGo iOS/KataGo Anytime.xcodeproj" \
+  -scheme "KataGo Anytime" \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -configuration Debug
+```
+Expected: BUILD SUCCEEDED.
+
+```bash
+xcodebuild build -project "ios/KataGo iOS/KataGo Anytime.xcodeproj" \
+  -scheme "KataGo Anytime" \
+  -destination 'platform=macOS' \
+  -configuration Debug
+```
+Expected: BUILD SUCCEEDED.
+
+```bash
+xcodebuild build -project "ios/KataGo iOS/KataGo Anytime.xcodeproj" \
+  -scheme "KataGo Anytime" \
+  -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+  -configuration Debug
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run:
+```bash
+xcodebuild test -project "ios/KataGo iOS/KataGo Anytime.xcodeproj" \
+  -scheme "KataGo Anytime" \
+  -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+Expected: All tests PASS, including the seven new/extended tests from Tasks 1–3 and all pre-existing tests (`RootViewBundleUpgradeTests`, `PrecompileSchedulerTests`, `PrecompileProjectionTests`, `CoreMLModelCacheTests`, etc.).
+
+- [ ] **Step 4: Manual smoke check (iOS Simulator, fresh install)**
+
+This step verifies the end-to-end behavior the spec describes. Do not skip — the unit tests cover the helper but not the integration with `hydrate` + cache events.
+
+1. Delete the app from the simulator: `xcrun simctl uninstall booted chinchangyang.KataGo-iOS.tw` (substitute your bundle id if different — check `Info.plist`).
+2. Run the app from Xcode on the iPhone 17 simulator.
+3. While the picker is on screen, watch the Console for `category: engine.coreml.cache`. Expected: a `precompile.failed` line absent; an `urlForKey` miss + commit for both `default_model.bin.gz` and `b18c384nbt-humanv0.bin.gz`.
+4. Open the picker's footer. After a few seconds (compile completes), expect `Main: 1 of 4` and `Human SL: 1 of 4`.
+5. Without launching the engine, force-quit the app and relaunch. Expect no new compile (cache hits) and the built-in row's checkmark visible immediately after `hydrate`.
+
+If any check above fails, capture the log line and stop — do not proceed to the commit step.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "ios/KataGo iOS/KataGo iOS/KataGo_iOSApp.swift"
+git commit -m "feat: sweep cache at app launch for built-in + human SL aux"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Section 1 → Task 4. Section 2 → Task 1. Section 3 → Task 4 (knownFileNames union). Section 4 → Tasks 3 + 4. Section 5 → Task 2. Section 6 tests → Tasks 1 (test 6/7 collapsed to one positive case; nil branch is defensive-only and not tested), 2 (test 5 + a coremlNE regression guard), 3 (tests 1–4).
+- **Placeholder scan:** no TBD / TODO / handle-edge-cases language. Every code step ships the full code.
+- **Type consistency:** `runCacheEmptySweep(scheduler:)` signature is identical in Task 3 (definition + test calls) and Task 4 (call sites). `autoWarmFileNames` is the same identifier across Tasks 3 and 4. The aux fileName string `"b18c384nbt-humanv0.bin.gz"` is the same across Tasks 1, 2, 3 and in production (`CoreMLModelCache.swift:873`, `KataGoHelper.swift:55`).

--- a/docs/superpowers/specs/2026-05-12-precompile-cache-empty-sweep-design.md
+++ b/docs/superpowers/specs/2026-05-12-precompile-cache-empty-sweep-design.md
@@ -1,0 +1,171 @@
+# Precompile Cache-Empty Sweep — Design
+
+**Status:** Approved by user 2026-05-12
+**Owner:** Chin-Chang Yang
+**Related specs:** `2026-05-09-coreml-cache-design.md`, `2026-05-11-coreml-cache-scheduler-gap-design.md`
+
+## Problem
+
+When the Core ML cache is empty (fresh install, after a `Clear Cache`, or after an interrupted/failed previous precompile), neither the built-in network (`default_model.bin.gz`) nor the bundled human SL aux network (`b18c384nbt-humanv0.bin.gz`) gets compiled in the background. The actual compile only happens reactively when the user starts a model, at which point the engine boot path performs the conversion.
+
+The current sole background trigger lives in `ModelRunnerView.onAppear`:
+
+```swift
+if BundleVersionWarmDecision.shouldRewarm(stored: lastWarmedVersion,
+                                          current: current) {
+    Task { await scheduler.scheduleBuiltIn() }
+    lastWarmedVersion = current
+}
+```
+
+Two problems:
+
+1. **`lastWarmedVersion` is written eagerly** (before the detached `Task` completes). If the precompile is interrupted or fails, the cache stays empty but the AppStorage key matches the current bundle — `shouldRewarm` returns false on the next launch, so the warm never re-fires.
+2. **The aux network is never auto-scheduled** at app launch. `scheduleBuiltIn()` only covers `default_model.bin.gz`.
+
+## Expected behavior
+
+When the cache is missing an entry for the built-in network or the human SL aux network, the scheduler should precompile it in the background at app launch. Bundle-version-based rewarming for the built-in is preserved (belt-and-suspenders).
+
+## Design
+
+### Section 1: Where the new logic lives
+
+- **App-launch flow** (`KataGo_iOSApp.swift` `.task` blocks for iOS / macOS / visionOS) gains a *cache-empty sweep* that fires after `await scheduler.hydrate(...)` completes.
+- **`ModelRunnerView.onAppear`'s bundle-version-based `scheduleBuiltIn()` is kept unchanged.** This is the "version changed since last warm" branch; the new sweep is the "cache is missing the entry" branch. They cooperate via `scheduleForModel`'s existing `inFlight` dedup.
+- **`PrecompileScheduler` gets no new public methods.** The sweep just calls `scheduleForModel(fileName:)` per missing file.
+- The app reads readiness via the existing public `status` map (`status[fileName] == .ready`).
+
+### Section 2: Aux projection — extend `makeProjectionResolver`
+
+`PrecompileProjection.swift`'s `makeProjectionResolver()` currently walks `NeuralNetworkModel.allCases`. The aux model is not in that list (it's not a user-selectable main), so we add a fileName special case before the `allCases` lookup:
+
+```swift
+func makeProjectionResolver() -> ProjectionResolver {
+    return { fileName in
+        if fileName == "b18c384nbt-humanv0.bin.gz" {
+            guard let bundlePath = Bundle.main.path(
+                    forResource: "b18c384nbt-humanv0",
+                    ofType: "bin.gz"),
+                  let builtIn = NeuralNetworkModel.builtInModel
+            else { return nil }
+            let settings = BackendSettings(model: builtIn)
+            let nnLen = Int32(settings.effectiveMaxBoardLength)
+            return ProjectionInputs(
+                sourcePath: bundlePath,
+                nnXLen: nnLen, nnYLen: nnLen,
+                requireExactNNLen: settings.requireExactNNLen,
+                useFP16: true, maxBatchSize: 1)
+        }
+        // existing allCases path unchanged
+        ...
+    }
+}
+```
+
+**Why built-in's settings?** The aux is loaded by the C++ engine alongside the main model, sharing `nnXLen/nnYLen/requireExactNNLen`. At app launch no main model is selected yet; the built-in is the most-common pairing and the only model guaranteed to be available without a download. Projecting against built-in's settings means the precompiled aux is reused verbatim when the user picks the built-in.
+
+**Implication if user picks a different main with different `nnLen`:** the aux will need a separate compile at engine boot. That's an acceptable cost for keeping the cache-empty sweep simple — the alternative (precompile aux for every possible main's settings) explodes the cache.
+
+### Section 3: Track aux in hydrate / subscription
+
+In `KataGo_iOSApp.swift`, extend the `knownFileNames` set in both `.task` blocks:
+
+```swift
+let knownFileNames = Set(NeuralNetworkModel.allCases.map(\.fileName))
+    .union(["b18c384nbt-humanv0.bin.gz"])
+```
+
+This makes `hydrate(...)` and `subscribeToCacheEvents(...)` cover the aux, so:
+
+- `status[aux] == .ready` after hydrate iff the aux's projected digest is in the cache index.
+- After a `cache.indexEvents` tick (e.g., the engine boot compiled aux on first launch), the aux's `cachedReady` bit is updated.
+
+No UI surface change: there is no picker row for aux, so the badge view is untouched. The sweep just needs accurate `status[aux]`.
+
+### Section 4: The cache-empty sweep
+
+Add a free function in `KataGo_iOSApp.swift` (so both `.task` branches and the new test target call the same code path):
+
+```swift
+@MainActor
+func runCacheEmptySweep(scheduler: PrecompileScheduler) async {
+    let warmTargets = ["default_model.bin.gz", "b18c384nbt-humanv0.bin.gz"]
+    for fileName in warmTargets {
+        if scheduler.status[fileName] != .ready {
+            await scheduler.scheduleForModel(fileName: fileName)
+        }
+    }
+}
+```
+
+Call it from each `.task` immediately after the `hydrate(...) + subscribeToCacheEvents(...)` pair:
+
+```swift
+await runCacheEmptySweep(scheduler: precompileScheduler)
+```
+
+Notes:
+
+- Runs once per scene `.task` lifecycle (same cadence as `hydrate`). SwiftUI re-fires `.task` on scene reactivation, which is acceptable — the dedup below makes repeated calls cheap.
+- `scheduleForModel`'s `inFlight` set dedupes against an already-running compile, so race with `ModelRunnerView.onAppear`'s bundle-version rewarm is harmless.
+- Status check uses `!= .ready` (not `== .idle`) so that a transient `.queued` / `.compiling` / `.failed` state already produced by the bundle-version rewarm path is not double-scheduled. (`.failed` is the deliberate retry-gate; the next user-driven trigger surfaces it.)
+- mpsGPU skip is enforced inside `scheduleForModel` — see Section 5.
+
+### Section 5: mpsGPU skip semantics for aux
+
+`scheduleForModel` currently skips when `defaults.string(forKey: "backend_\(fileName)") == "mpsGPU"`. For aux, the key `backend_b18c384nbt-humanv0.bin.gz` is never written by any UI surface (no backend picker for aux), so the existing check would never fire — but the aux's projection borrows the built-in's settings, so its mpsGPU-vs-CoreML choice should track the built-in.
+
+**Change:** inside `scheduleForModel`, when `fileName == "b18c384nbt-humanv0.bin.gz"`, consult `backend_default_model.bin.gz` for the skip decision:
+
+```swift
+let backendKey: String
+if fileName == "b18c384nbt-humanv0.bin.gz" {
+    backendKey = "backend_default_model.bin.gz"
+} else {
+    backendKey = "backend_\(fileName)"
+}
+if defaults.string(forKey: backendKey) == "mpsGPU" {
+    log.info("skip-precompile reason=mpsGPU fileName=\(fileName, privacy: .public)")
+    return
+}
+```
+
+The aux's skip policy now matches its projection policy: both inherit from the built-in.
+
+### Section 6: Tests
+
+#### New file: `KataGo iOSTests/AppLaunchPrecompileSweepTests.swift`
+
+Tests call `runCacheEmptySweep(scheduler:)` directly against a `PrecompileScheduler` seeded with the desired `status` map via the existing `_setEphemeralForTests` / `_setCachedReadyForTests` debug seams. They verify:
+
+1. **Empty cache → both scheduled.** Fake scheduler reports `status[*] = .idle`; sweep calls `scheduleForModel` for both targets exactly once.
+2. **Built-in ready, aux missing → only aux scheduled.** `status[builtIn] = .ready`, `status[aux] = .idle` → one call, fileName == aux.
+3. **Both ready → no schedules.** Sweep is a no-op.
+4. **Queued / compiling does not re-schedule.** `status[aux] = .compiling` → sweep does not call `scheduleForModel(aux)`.
+
+#### Extend `PrecompileSchedulerTests`
+
+5. **`scheduleForModel(aux)` skipped when `backend_default_model.bin.gz == "mpsGPU"`.** Mirror the existing mpsGPU-skip test, with aux fileName + built-in's backend key in defaults.
+
+#### New tests in `PrecompileProjectionTests` (or extend existing)
+
+6. **`makeProjectionResolver()(aux)` returns non-nil with built-in's `nnLen` and `requireExactNNLen`.** Verifies the Section-2 extension without touching the cache.
+7. **`makeProjectionResolver()(aux)` returns nil when `NeuralNetworkModel.builtInModel` is nil.** Edge case; defensive guard.
+
+Existing tests stay:
+
+- `RootViewBundleUpgradeTests` — bundle-version rewarm path is unchanged.
+- `PrecompileSchedulerTests` — existing dedup / cancelAllPending / cacheEventTick tests are unaffected.
+
+## Non-goals
+
+- **Downloaded main models are not swept.** Per agreement, only built-in + aux. A downloaded model's precompile remains tied to its existing `downloader.onDownloadComplete` hook in `ModelPickerView`.
+- **No UI surface for aux readiness.** No new badge row, no new footer line. `status[aux]` is consumed only by the sweep's gating logic.
+- **No removal of bundle-version rewarm.** The two triggers cooperate.
+- **No change to `cache.warm` / converter / cache-key semantics.** The sweep reuses the existing precompile worker.
+
+## Risks / open points
+
+- **Aux compile races with engine boot.** On a first launch, the sweep fires aux precompile in background; concurrently the user picks a model and the engine boot also compiles aux. The cache's `urlForKey` already handles concurrent misses via its per-digest `inFlight` map (see `CoreMLModelCache`); the second arriver waits on the first. No new risk introduced.
+- **macOS / visionOS code duplication.** `KataGo_iOSApp.swift` has parallel `.task` blocks per platform. The sweep should be factored into a single helper called from both branches to avoid drift.

--- a/ios/KataGo iOS/KataGo Anytime.xcodeproj/project.pbxproj
+++ b/ios/KataGo iOS/KataGo Anytime.xcodeproj/project.pbxproj
@@ -487,6 +487,7 @@
 		E18F3E182A51466C00D335E1 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E18F3E172A51466C00D335E1 /* Preview Assets.xcassets */; };
 		E18F3E2C2A51466C00D335E1 /* KataGo_iOSUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18F3E2B2A51466C00D335E1 /* KataGo_iOSUITests.swift */; };
 		AABBCCDD2A51466C00D335E1 /* CoreMLCacheFooterUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCCDE2A51466C00D335E1 /* CoreMLCacheFooterUITests.swift */; };
+		AABBCCE02A51466C00D335E1 /* CacheEmptySweepFooterUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCCDF2A51466C00D335E1 /* CacheEmptySweepFooterUITests.swift */; };
 		E18F3E2E2A51466C00D335E1 /* KataGo_iOSUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18F3E2D2A51466C00D335E1 /* KataGo_iOSUITestsLaunchTests.swift */; };
 		E18F3F722A5149B300D335E1 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E18F3F712A5149AB00D335E1 /* libz.tbd */; };
 		E18F3F772A514B9700D335E1 /* default_model.bin.gz in Resources */ = {isa = PBXBuildFile; fileRef = E18F3F742A514B9700D335E1 /* default_model.bin.gz */; };
@@ -1086,6 +1087,7 @@
 		E18F3E272A51466C00D335E1 /* KataGo AnytimeUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "KataGo AnytimeUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E18F3E2B2A51466C00D335E1 /* KataGo_iOSUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KataGo_iOSUITests.swift; sourceTree = "<group>"; };
 		AABBCCDE2A51466C00D335E1 /* CoreMLCacheFooterUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMLCacheFooterUITests.swift; sourceTree = "<group>"; };
+		AABBCCDF2A51466C00D335E1 /* CacheEmptySweepFooterUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheEmptySweepFooterUITests.swift; sourceTree = "<group>"; };
 		E18F3E2D2A51466C00D335E1 /* KataGo_iOSUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KataGo_iOSUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		E18F3F712A5149AB00D335E1 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		E18F3F742A514B9700D335E1 /* default_model.bin.gz */ = {isa = PBXFileReference; lastKnownFileType = archive.gzip; path = default_model.bin.gz; sourceTree = "<group>"; };
@@ -1951,6 +1953,7 @@
 				E18F3E2B2A51466C00D335E1 /* KataGo_iOSUITests.swift */,
 				E18F3E2D2A51466C00D335E1 /* KataGo_iOSUITestsLaunchTests.swift */,
 				AABBCCDE2A51466C00D335E1 /* CoreMLCacheFooterUITests.swift */,
+				AABBCCDF2A51466C00D335E1 /* CacheEmptySweepFooterUITests.swift */,
 			);
 			path = "KataGo iOSUITests";
 			sourceTree = "<group>";
@@ -2819,6 +2822,7 @@
 				E18F3E2C2A51466C00D335E1 /* KataGo_iOSUITests.swift in Sources */,
 				E18F3E2E2A51466C00D335E1 /* KataGo_iOSUITestsLaunchTests.swift in Sources */,
 				AABBCCDD2A51466C00D335E1 /* CoreMLCacheFooterUITests.swift in Sources */,
+				AABBCCE02A51466C00D335E1 /* CacheEmptySweepFooterUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/KataGo iOS/KataGo Anytime.xcodeproj/project.pbxproj
+++ b/ios/KataGo iOS/KataGo Anytime.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		553DBC10CF58E3BB94880AA4 /* arg.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0B40E0A9D40BE4F1BFF2939B /* arg.cc */; };
 		55F3DCC168CA4E457E7516A7 /* mutex.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0A85319AE10A8198A3117ADE /* mutex.cc */; };
 		57106766F3F29CAD99F9BF2D /* nullguard.cc in Sources */ = {isa = PBXBuildFile; fileRef = 55915A5FD9CB10142DE64426 /* nullguard.cc */; };
+		46E9CE44951859F486FDFC20 /* AppLaunchPrecompileSweepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FC60CB92B55467A3D11DAC /* AppLaunchPrecompileSweepTests.swift */; };
 		57304D90A4E5D0F2A36C113F /* PrecompileSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC60437A95B0170C6CBAC8DD /* PrecompileSchedulerTests.swift */; };
 		57AB2F792F63982215ED36A6 /* TextClassifier.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 4B353F521781321D83987622 /* TextClassifier.pb.cc */; };
 		57C30FBD9D80117903FCC4E2 /* TreeEnsemble.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = A73862C30379DA9F05C0DF6C /* TreeEnsemble.pb.cc */; };
@@ -791,6 +792,7 @@
 		BC2CF6DCF3C1E8EF28EA94A2 /* MMapFileReaderFactory.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MMapFileReaderFactory.cpp; path = ../../cpp/external/katagocoreml/vendor/mlmodel/src/MILBlob/Blob/MMapFileReaderFactory.cpp; sourceTree = SOURCE_ROOT; };
 		BC369E122AA45A565227D30F /* elf_mem_image.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = elf_mem_image.cc; path = "../../cpp/external/abseil-cpp-20260107.1/absl/debugging/internal/elf_mem_image.cc"; sourceTree = SOURCE_ROOT; };
 		BC384FBBA433A17AF90C2F1F /* CoreMLCacheKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CoreMLCacheKeyTests.swift; path = "KataGo iOSTests/CoreMLCacheKeyTests.swift"; sourceTree = SOURCE_ROOT; };
+		54FC60CB92B55467A3D11DAC /* AppLaunchPrecompileSweepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppLaunchPrecompileSweepTests.swift; path = "KataGo iOSTests/AppLaunchPrecompileSweepTests.swift"; sourceTree = SOURCE_ROOT; };
 		BC60437A95B0170C6CBAC8DD /* PrecompileSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PrecompileSchedulerTests.swift; path = "KataGo iOSTests/PrecompileSchedulerTests.swift"; sourceTree = SOURCE_ROOT; };
 		BD22490FB6D2F00C83C1BD22 /* Fp16.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Fp16.cpp; path = ../../cpp/external/katagocoreml/vendor/mlmodel/src/MILBlob/Fp16.cpp; sourceTree = SOURCE_ROOT; };
 		BE2564FBAA9E809482077069 /* arenaz_sampler.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = arenaz_sampler.cc; path = "../../cpp/external/protobuf-34.1/src/google/protobuf/arenaz_sampler.cc"; sourceTree = SOURCE_ROOT; };
@@ -1884,6 +1886,7 @@
 				BC384FBBA433A17AF90C2F1F /* CoreMLCacheKeyTests.swift */,
 				757D4B93AD8FB611D5BE3C60 /* CoreMLModelCacheTests.swift */,
 				04354F7785F6492BE5E2498F /* BinFileHasherTests.swift */,
+				54FC60CB92B55467A3D11DAC /* AppLaunchPrecompileSweepTests.swift */,
 				BC60437A95B0170C6CBAC8DD /* PrecompileSchedulerTests.swift */,
 				8A8C40769F7BCFDF7F1F74DD /* RootViewBundleUpgradeTests.swift */,
 				CC00000000000000F6000002 /* PrecompileProjection.swift */,
@@ -2802,6 +2805,7 @@
 				BF60411C8AF4BB983A288118 /* CoreMLCacheKeyTests.swift in Sources */,
 				535E4E2D903B23E105F6D0F4 /* CoreMLModelCacheTests.swift in Sources */,
 				717643FC8292874AF4166C70 /* BinFileHasherTests.swift in Sources */,
+				46E9CE44951859F486FDFC20 /* AppLaunchPrecompileSweepTests.swift in Sources */,
 				57304D90A4E5D0F2A36C113F /* PrecompileSchedulerTests.swift in Sources */,
 				AE574ABD9822214B5255D39E /* RootViewBundleUpgradeTests.swift in Sources */,
 				CC00000000000000F6000003 /* PrecompileProjectionTests.swift in Sources */,

--- a/ios/KataGo iOS/KataGo iOS/KataGo_iOSApp.swift
+++ b/ios/KataGo iOS/KataGo iOS/KataGo_iOSApp.swift
@@ -87,6 +87,7 @@ struct KataGo_iOSApp: App {
                     .environment(engineLaunchStatus)
                     .task {
                         let knownFileNames = Set(NeuralNetworkModel.allCases.map(\.fileName))
+                            .union(autoWarmFileNames)
                         let digestFor = makeProjectionDigestFor()
                         await CoreMLModelCache.shared.start()
                         await precompileScheduler.hydrate(
@@ -97,6 +98,7 @@ struct KataGo_iOSApp: App {
                             .shared,
                             fileNames: knownFileNames,
                             digestFor: digestFor)
+                        await runCacheEmptySweep(scheduler: precompileScheduler)
                     }
             }
         #else
@@ -106,6 +108,7 @@ struct KataGo_iOSApp: App {
                     .environment(engineLaunchStatus)
                     .task {
                         let knownFileNames = Set(NeuralNetworkModel.allCases.map(\.fileName))
+                            .union(autoWarmFileNames)
                         let digestFor = makeProjectionDigestFor()
                         await CoreMLModelCache.shared.start()
                         await precompileScheduler.hydrate(
@@ -116,6 +119,7 @@ struct KataGo_iOSApp: App {
                             .shared,
                             fileNames: knownFileNames,
                             digestFor: digestFor)
+                        await runCacheEmptySweep(scheduler: precompileScheduler)
                     }
             }
         #endif

--- a/ios/KataGo iOS/KataGo iOS/KataGo_iOSApp.swift
+++ b/ios/KataGo iOS/KataGo iOS/KataGo_iOSApp.swift
@@ -10,6 +10,32 @@ import SwiftData
 import SwiftUI
 import KataGoInterface
 
+/// File names auto-warmed at app launch when their cache entry is
+/// missing. Built-in + bundled human SL aux only — downloaded mains
+/// are handled by `ModelPickerView.downloader.onDownloadComplete`.
+private let autoWarmFileNames: [String] = [
+    "default_model.bin.gz",
+    "b18c384nbt-humanv0.bin.gz"
+]
+
+/// Cache-empty sweep. For each auto-warm target whose status is not
+/// `.ready`, enqueue a precompile. Runs after `scheduler.hydrate(...)`
+/// in the app's scene `.task`. `scheduleForModel`'s `inFlight` dedup
+/// makes repeated calls (e.g. scene reactivation) cheap, and the
+/// bundle-version rewarm in `ModelRunnerView.onAppear` cooperates via
+/// the same dedup path.
+@MainActor
+func runCacheEmptySweep(scheduler: PrecompileScheduler) async {
+    for fileName in autoWarmFileNames {
+        switch scheduler.status[fileName] {
+        case .ready, .queued, .compiling:
+            break
+        default:
+            await scheduler.scheduleForModel(fileName: fileName)
+        }
+    }
+}
+
 @main
 struct KataGo_iOSApp: App {
     @State private var precompileScheduler: PrecompileScheduler = PrecompileScheduler(

--- a/ios/KataGo iOS/KataGo iOS/KataGo_iOSApp.swift
+++ b/ios/KataGo iOS/KataGo iOS/KataGo_iOSApp.swift
@@ -19,9 +19,12 @@ private let autoWarmFileNames: [String] = [
 ]
 
 /// Cache-empty sweep. For each auto-warm target whose status is not
-/// `.ready`, enqueue a precompile. Runs after `scheduler.hydrate(...)`
-/// in the app's scene `.task`. `scheduleForModel`'s `inFlight` dedup
-/// makes repeated calls (e.g. scene reactivation) cheap, and the
+/// `.ready`, `.queued`, or `.compiling`, enqueue a precompile. Runs
+/// after `scheduler.hydrate(...)` in the app's scene `.task`. The
+/// gating switch skips in-flight targets at the helper boundary;
+/// `scheduleForModel`'s `inFlight` set is a defense-in-depth backstop.
+/// On scene reactivation a target's status may be `.idle` again, in
+/// which case the call lands but is deduped by `inFlight`. The
 /// bundle-version rewarm in `ModelRunnerView.onAppear` cooperates via
 /// the same dedup path.
 @MainActor

--- a/ios/KataGo iOS/KataGo iOS/PrecompileProjection.swift
+++ b/ios/KataGo iOS/KataGo iOS/PrecompileProjection.swift
@@ -39,6 +39,28 @@ typealias ProjectionResolver = (_ fileName: String) -> ProjectionInputs?
 /// cache key.
 func makeProjectionResolver() -> ProjectionResolver {
     return { fileName in
+        // Human SL aux is bundled and shares the built-in's backend
+        // settings (the engine loads them together with the same nnLen
+        // and same fp16/maxBatchSize). Project its digest against the
+        // built-in's settings so the precompiled aux is reused verbatim
+        // when the user selects the built-in.
+        if fileName == "b18c384nbt-humanv0.bin.gz" {
+            guard let bundlePath = Bundle.main.path(
+                    forResource: "b18c384nbt-humanv0",
+                    ofType: "bin.gz"),
+                  let builtIn = NeuralNetworkModel.builtInModel
+            else { return nil }
+            let settings = BackendSettings(model: builtIn)
+            let nnLen = Int32(settings.effectiveMaxBoardLength)
+            return ProjectionInputs(
+                sourcePath: bundlePath,
+                nnXLen: nnLen,
+                nnYLen: nnLen,
+                requireExactNNLen: settings.requireExactNNLen,
+                useFP16: true,
+                maxBatchSize: 1)
+        }
+
         guard let model = NeuralNetworkModel.allCases.first(where: { $0.fileName == fileName })
         else { return nil }
 

--- a/ios/KataGo iOS/KataGo iOS/PrecompileScheduler.swift
+++ b/ios/KataGo iOS/KataGo iOS/PrecompileScheduler.swift
@@ -71,7 +71,15 @@ public final class PrecompileScheduler {
     /// inherits `@MainActor` isolation; status mutations happen on-actor
     /// and the worker's own async suspension takes it off-actor as needed.
     public func scheduleForModel(fileName: String) async {
-        if defaults.string(forKey: "backend_\(fileName)") == "mpsGPU" {
+        // Aux's projection borrows the built-in's BackendSettings, so its
+        // mpsGPU-vs-CoreML skip decision must also follow the built-in.
+        // The aux's own `backend_<aux>` key is never written by any UI
+        // surface, so reading it would always be nil and the aux would
+        // never be skipped — which would diverge from the projection.
+        let backendKey: String = (fileName == "b18c384nbt-humanv0.bin.gz")
+            ? "backend_default_model.bin.gz"
+            : "backend_\(fileName)"
+        if defaults.string(forKey: backendKey) == "mpsGPU" {
             log.info("skip-precompile reason=mpsGPU fileName=\(fileName, privacy: .public)")
             return
         }

--- a/ios/KataGo iOS/KataGo iOSTests/AppLaunchPrecompileSweepTests.swift
+++ b/ios/KataGo iOS/KataGo iOSTests/AppLaunchPrecompileSweepTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+import KataGoInterface
+@testable import KataGo_Anytime
+
+struct AppLaunchPrecompileSweepTests {
+
+    // Shared fixture: scheduler whose worker only counts invocations
+    // per fileName. Backend keys are left unset in the per-test
+    // UserDefaults suite so the mpsGPU skip never fires.
+    private func makeFixture() async -> (PrecompileScheduler, FileNameCounter) {
+        let defaults = UserDefaults(suiteName: "test.\(UUID())")!
+        let counter = FileNameCounter()
+        let scheduler = await PrecompileScheduler(defaults: defaults) { fileName in
+            await counter.inc(fileName)
+        }
+        return (scheduler, counter)
+    }
+
+    actor FileNameCounter {
+        private var counts: [String: Int] = [:]
+        func inc(_ fileName: String) { counts[fileName, default: 0] += 1 }
+        func count(_ fileName: String) -> Int { counts[fileName] ?? 0 }
+        func total() -> Int { counts.values.reduce(0, +) }
+    }
+
+    @MainActor
+    @Test func sweepsBothWhenCacheEmpty() async throws {
+        let (scheduler, counter) = await makeFixture()
+        // status is empty -> both targets are not .ready.
+
+        await runCacheEmptySweep(scheduler: scheduler)
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(await counter.count("default_model.bin.gz") == 1)
+        #expect(await counter.count("b18c384nbt-humanv0.bin.gz") == 1)
+        #expect(await counter.total() == 2)
+    }
+
+    @MainActor
+    @Test func sweepsOnlyAuxWhenBuiltInReady() async throws {
+        let (scheduler, counter) = await makeFixture()
+        scheduler._setCachedReadyForTests(["default_model.bin.gz"])
+
+        await runCacheEmptySweep(scheduler: scheduler)
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(await counter.count("default_model.bin.gz") == 0)
+        #expect(await counter.count("b18c384nbt-humanv0.bin.gz") == 1)
+    }
+
+    @MainActor
+    @Test func sweepsNothingWhenBothReady() async throws {
+        let (scheduler, counter) = await makeFixture()
+        scheduler._setCachedReadyForTests([
+            "default_model.bin.gz",
+            "b18c384nbt-humanv0.bin.gz"
+        ])
+
+        await runCacheEmptySweep(scheduler: scheduler)
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(await counter.total() == 0)
+    }
+
+    @MainActor
+    @Test func sweepDoesNotReScheduleQueuedOrCompiling() async throws {
+        let (scheduler, counter) = await makeFixture()
+        scheduler._setEphemeralForTests([
+            "default_model.bin.gz": .compiling,
+            "b18c384nbt-humanv0.bin.gz": .queued
+        ])
+
+        await runCacheEmptySweep(scheduler: scheduler)
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Neither target is .ready, but both are in-flight. The sweep
+        // calls scheduleForModel anyway; scheduleForModel's inFlight
+        // dedup is what blocks the worker from being invoked again.
+        // What we assert here is the user-visible outcome: the worker
+        // is not run a second time.
+        #expect(await counter.count("default_model.bin.gz") == 0)
+        #expect(await counter.count("b18c384nbt-humanv0.bin.gz") == 0)
+    }
+}

--- a/ios/KataGo iOS/KataGo iOSTests/AppLaunchPrecompileSweepTests.swift
+++ b/ios/KataGo iOS/KataGo iOSTests/AppLaunchPrecompileSweepTests.swift
@@ -74,11 +74,12 @@ struct AppLaunchPrecompileSweepTests {
         await runCacheEmptySweep(scheduler: scheduler)
         try await Task.sleep(for: .milliseconds(50))
 
-        // Neither target is .ready, but both are in-flight. The sweep
-        // calls scheduleForModel anyway; scheduleForModel's inFlight
-        // dedup is what blocks the worker from being invoked again.
+        // The switch in runCacheEmptySweep skips .queued and .compiling
+        // directly — scheduleForModel is never called for either target.
+        // scheduleForModel's inFlight set provides a defense-in-depth
+        // backstop if the gating condition is ever relaxed.
         // What we assert here is the user-visible outcome: the worker
-        // is not run a second time.
+        // is not invoked a second time.
         #expect(await counter.count("default_model.bin.gz") == 0)
         #expect(await counter.count("b18c384nbt-humanv0.bin.gz") == 0)
     }

--- a/ios/KataGo iOS/KataGo iOSTests/PrecompileProjectionTests.swift
+++ b/ios/KataGo iOS/KataGo iOSTests/PrecompileProjectionTests.swift
@@ -18,4 +18,27 @@ struct PrecompileProjectionTests {
             #expect(inputs.sourcePath.hasSuffix("default_model.bin.gz"))
         }
     }
+
+    @Test func resolverReturnsInputsForHumanSLAux() async throws {
+        let inputs = makeProjectionResolver()("b18c384nbt-humanv0.bin.gz")
+        #expect(inputs != nil)
+        guard let inputs else { return }
+        #expect(inputs.sourcePath.hasSuffix("b18c384nbt-humanv0.bin.gz"))
+        #expect(inputs.nnXLen > 0)
+        #expect(inputs.nnYLen > 0)
+        #expect(inputs.nnXLen == inputs.nnYLen)
+        #expect(inputs.useFP16 == true)
+        #expect(inputs.maxBatchSize == 1)
+
+        // Aux projection must mirror the built-in's settings: same nnLen
+        // and same requireExactNNLen so the cache key matches what the
+        // engine launch will compute when the built-in is selected.
+        let builtIn = makeProjectionResolver()("default_model.bin.gz")
+        #expect(builtIn != nil)
+        if let builtIn {
+            #expect(inputs.nnXLen == builtIn.nnXLen)
+            #expect(inputs.nnYLen == builtIn.nnYLen)
+            #expect(inputs.requireExactNNLen == builtIn.requireExactNNLen)
+        }
+    }
 }

--- a/ios/KataGo iOS/KataGo iOSTests/PrecompileSchedulerTests.swift
+++ b/ios/KataGo iOS/KataGo iOSTests/PrecompileSchedulerTests.swift
@@ -212,6 +212,36 @@ struct PrecompileSchedulerTests {
         #expect(await scheduler.status["a.bin.gz"] == nil)
     }
 
+    @Test func skipsAuxWhenBuiltInBackendIsMpsGpu() async throws {
+        let defaults = UserDefaults(suiteName: "test.\(UUID())")!
+        defaults.set("mpsGPU", forKey: "backend_default_model.bin.gz")
+
+        actor Counter { var n = 0; func inc() { n += 1 }; func get() -> Int { n } }
+        let counter = Counter()
+        let scheduler = await PrecompileScheduler(defaults: defaults) { _ in
+            await counter.inc()
+        }
+        await scheduler.scheduleForModel(fileName: "b18c384nbt-humanv0.bin.gz")
+
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await counter.get() == 0)
+    }
+
+    @Test func runsAuxWhenBuiltInBackendIsCoreml() async throws {
+        let defaults = UserDefaults(suiteName: "test.\(UUID())")!
+        defaults.set("coremlNE", forKey: "backend_default_model.bin.gz")
+
+        actor Counter { var n = 0; func inc() { n += 1 }; func get() -> Int { n } }
+        let counter = Counter()
+        let scheduler = await PrecompileScheduler(defaults: defaults) { _ in
+            await counter.inc()
+        }
+        await scheduler.scheduleForModel(fileName: "b18c384nbt-humanv0.bin.gz")
+
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await counter.get() == 1)
+    }
+
     @MainActor
     @Test func cancelAllPendingPreservesCachedReady() async throws {
         let scheduler = PrecompileScheduler(worker: { _ in })

--- a/ios/KataGo iOS/KataGo iOSUITests/CacheEmptySweepFooterUITests.swift
+++ b/ios/KataGo iOS/KataGo iOSUITests/CacheEmptySweepFooterUITests.swift
@@ -1,0 +1,129 @@
+//
+//  CacheEmptySweepFooterUITests.swift
+//  KataGo iOSUITests
+//
+//  Verifies the launch-time cache-empty sweep precompiles both the
+//  built-in network and the bundled human SL aux. After clearing the
+//  cache from inside the app, terminating, and relaunching, the
+//  footer's `.task` reads fresh stats and should eventually show:
+//
+//      Main:     1 of 4 · …
+//      Human SL: 1 of 4 · …
+//
+//  Footer staleness: `CoreMLCacheFooterView.refresh()` only runs from
+//  `.task` at view-appearance — it does NOT observe live cache events.
+//  The test therefore terminates + relaunches the app between checks
+//  so the footer's first read on each launch reflects the latest
+//  on-disk cache state. Each terminate that lands during a compile
+//  also kills that in-flight worker; the cache write protocol is
+//  atomic, so killed compiles leave no committed entry and are
+//  retried on the next launch's sweep.
+//
+
+import XCTest
+
+final class CacheEmptySweepFooterUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testAppLaunchSweepPopulatesBuiltInAndAux() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // ----- Step 1: clear the cache from inside the running app ------
+        // The footer's "Clear Cache" button is only present when
+        // totalCount > 0. If the cache is already empty, skip.
+        let clearButton = app.buttons["Clear Cache"]
+        let mainFooter  = app.staticTexts["CoreMLCache.footerMainStats"]
+        let auxFooter   = app.staticTexts["CoreMLCache.footerAuxStats"]
+        XCTAssertTrue(mainFooter.waitForExistence(timeout: 30),
+                      "Main-pool footer line never appeared")
+        if clearButton.waitForExistence(timeout: 10) {
+            clearButton.tap()
+            let confirmClear = app.buttons["Clear"]
+            XCTAssertTrue(confirmClear.waitForExistence(timeout: 10),
+                          "Clear-Cache confirmation dialog did not appear")
+            confirmClear.tap()
+            let clearGone = NSPredicate(format: "exists == false")
+            expectation(for: clearGone, evaluatedWith: clearButton)
+            waitForExpectations(timeout: 30)
+        }
+
+        // Terminate to kill any in-flight compile triggered by clear()'s
+        // own scheduleBuiltIn(). The atomic cache-commit protocol
+        // guarantees no partial entry survives the kill.
+        app.terminate()
+
+        // ----- Step 2: poll terminate+launch cycles until the cache
+        // has both entries and the footer reflects them. Per-cycle
+        // sleep gives the launch-time sweep time to commit one compile
+        // before the next terminate. Empirically a single isolated
+        // compile in this simulator is ~80–120s, but two compiles
+        // running concurrently under CPU contention can take 5+ min,
+        // so cycle the launches: the first cycle typically finishes
+        // the aux, the second finishes the built-in. ----------------
+        let perCycleSleep: TimeInterval = 180   // generous per-compile window
+        let maxCycles = 6                       // total budget ≈ 18 minutes
+        var lastMainLabel = ""
+        var lastAuxLabel  = ""
+        var bothReady = false
+        for cycle in 1...maxCycles {
+            app.launch()
+            XCTAssertTrue(mainFooter.waitForExistence(timeout: 30),
+                          "Picker did not appear on cycle \(cycle) relaunch")
+            // Sleep with the app foregrounded so background compiles
+            // run; .utility priority on the cooperative pool is what
+            // executes Core ML conversions here.
+            Thread.sleep(forTimeInterval: perCycleSleep)
+
+            // Probe the footer by terminating + relaunching: the next
+            // launch's .task will re-read CoreMLModelCache.statsByCategory()
+            // and reflect whatever was committed during the sleep.
+            app.terminate()
+            app.launch()
+            XCTAssertTrue(mainFooter.waitForExistence(timeout: 30),
+                          "Picker did not appear on cycle \(cycle) probe relaunch")
+            XCTAssertTrue(auxFooter.waitForExistence(timeout: 30),
+                          "Aux-pool footer not present on cycle \(cycle)")
+            // Give the footer's .task one tick to refresh() before reading.
+            Thread.sleep(forTimeInterval: 3)
+            lastMainLabel = mainFooter.label
+            lastAuxLabel  = auxFooter.label
+            let mainCount = parseCount(lastMainLabel)
+            let auxCount  = parseCount(lastAuxLabel)
+            if mainCount >= 1 && auxCount >= 1 {
+                bothReady = true
+                break
+            }
+            // Not done yet: terminate before the next cycle's launch
+            // so we get a fresh sweep firing.
+            app.terminate()
+        }
+
+        XCTAssertTrue(bothReady,
+                      "Sweep did not populate both pools within \(maxCycles) cycles. "
+                      + "Last seen — Main: '\(lastMainLabel)'; Aux: '\(lastAuxLabel)'")
+        // Tight assertion: count must be exactly 1 — the sweep should
+        // warm only the built-in + aux, nothing else.
+        XCTAssertEqual(parseCount(lastMainLabel), 1,
+                       "Expected Main: 1 of 4; footer was '\(lastMainLabel)'")
+        XCTAssertEqual(parseCount(lastAuxLabel), 1,
+                       "Expected Human SL: 1 of 4; footer was '\(lastAuxLabel)'")
+    }
+
+    /// Parses the "<Label>: N of M" fragment from a footer line.
+    /// Mirrors the helper in CoreMLCacheFooterUITests.
+    private func parseCount(_ label: String) -> Int {
+        guard let range = label.range(of: #":\s*(\d+)\s+of\s+\d+"#,
+                                       options: .regularExpression) else {
+            return -1
+        }
+        let match = String(label[range])
+        let digits = match.drop { !$0.isNumber }
+                          .prefix { $0.isNumber }
+        return Int(digits) ?? -1
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes a bug where the Core ML cache was never populated in the background — the built-in network and bundled human SL aux only got compiled when the user actually started the engine. Now both are precompiled automatically at app launch whenever the cache is missing their entries.
- Adds a `runCacheEmptySweep` helper that, after `scheduler.hydrate(...)`, schedules any auto-warm target (`default_model.bin.gz`, `b18c384nbt-humanv0.bin.gz`) whose status is not `.ready`/`.queued`/`.compiling`.
- Extends `makeProjectionResolver` to project the aux's digest against the built-in's `BackendSettings` so the precompiled aux is reused verbatim when the user picks the built-in.
- Extends `PrecompileScheduler.scheduleForModel`'s mpsGPU skip so the aux inherits the built-in's backend setting (consistent with the projection).
- Preserves the existing bundle-version rewarm in `ModelRunnerView.onAppear` (belt-and-suspenders).

## Commits

```
35fd92e1 feat: project human SL aux digest against built-in's settings
62e36ed9 feat: human SL aux inherits built-in's mpsGPU skip decision
fb64be48 feat: add runCacheEmptySweep helper for built-in + aux
1492c89c docs: correct sweep gating-mechanism comments
244b6c96 feat: sweep cache at app launch for built-in + human SL aux
2a9bec6f test: verify cache-empty sweep populates footer to 1/4 + 1/4
32679bc0 docs: spec and plan for precompile cache-empty sweep
```

Design + implementation plan live in `docs/superpowers/{specs,plans}/2026-05-12-precompile-cache-empty-sweep*`.

## Test plan

- [x] Unit tests: full `xcodebuild test` suite passes — 214/214 (`AppLaunchPrecompileSweepTests`, `PrecompileSchedulerTests`, `PrecompileProjectionTests`, all pre-existing).
- [x] UI test: `CacheEmptySweepFooterUITests.testAppLaunchSweepPopulatesBuiltInAndAux` exercises the end-to-end flow on iPhone 17 Simulator (clears cache → terminates → relaunches → polls until footer reads `Main: 1 of 4` and `Human SL: 1 of 4`). Passes in ~3.4 min on iPhone 17 Simulator. Lives in `FullTestPlan`, not `FastTestPlan` — does not run during the default test invocation.
- [x] Builds: iOS Simulator and macOS green. visionOS local build fails for a missing simulator-runtime reason (env, not a regression).
- [x] Manual smoke check on a real device cold-launch — confirm both compiles happen in the background while the picker is up, and the footer reads `1 of 4` for both rows after they finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)