### PR TITLE
Reduce on-device CoreML conversion peak memory (fix b40c768 OOM)

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -401,6 +401,7 @@ elseif(USE_BACKEND STREQUAL "TENSORRT")
   target_link_libraries(katago CUDA::cudart_static ${TENSORRT_LIBRARY})
 elseif(USE_BACKEND STREQUAL "METAL")
   target_compile_definitions(katago PRIVATE USE_METAL_BACKEND)
+  target_compile_definitions(katago PRIVATE KATAGO_COREML_CONVERT_TESTS)
   target_link_libraries(katago KataGoSwift katagocoreml
     ${KATAGOCOREML_DEP_LDFLAGS}
     "-framework MetalPerformanceShaders"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -282,6 +282,7 @@ add_executable(katago
   tests/testbook.cpp
   tests/testcommon.cpp
   tests/testconfig.cpp
+  tests/testcoremlconvert.cpp
   tests/testmisc.cpp
   tests/testnnevalcanary.cpp
   tests/testrules.cpp

--- a/cpp/command/runtests.cpp
+++ b/cpp/command/runtests.cpp
@@ -759,7 +759,7 @@ int MainCmds::runconfigtests(const vector<string>& args) {
 
 int MainCmds::runcoremlconverttests(const vector<string>& args) {
   (void)args;
-#ifdef USE_METAL_BACKEND
+#ifdef KATAGO_COREML_CONVERT_TESTS
   Tests::runCoremlConvertSmokeTest();
   Tests::runCoremlConvertCrossFormatTest();
   Tests::runCoremlConvertDeterminismTest();
@@ -768,7 +768,7 @@ int MainCmds::runcoremlconverttests(const vector<string>& args) {
   cout << "All CoreML converter tests passed" << endl;
   return 0;
 #else
-  cout << "runcoremlconverttests is only available in a METAL backend build" << endl;
+  cout << "runcoremlconverttests is only available in a METAL CMake build" << endl;
   return 0;
 #endif
 }

--- a/cpp/command/runtests.cpp
+++ b/cpp/command/runtests.cpp
@@ -761,7 +761,7 @@ int MainCmds::runcoremlconverttests(const vector<string>& args) {
   (void)args;
 #ifdef USE_METAL_BACKEND
   Tests::runCoremlConvertSmokeTest();
-  //Tests::runCoremlConvertCrossFormatTest();
+  Tests::runCoremlConvertCrossFormatTest();
   //Tests::runCoremlConvertDeterminismTest();
   //Tests::runCoremlConvertGoldenTest();
   //Tests::runCoremlConvertPeakMemoryTest();

--- a/cpp/command/runtests.cpp
+++ b/cpp/command/runtests.cpp
@@ -757,3 +757,19 @@ int MainCmds::runconfigtests(const vector<string>& args) {
   return 0;
 }
 
+int MainCmds::runcoremlconverttests(const vector<string>& args) {
+  (void)args;
+#ifdef USE_METAL_BACKEND
+  Tests::runCoremlConvertSmokeTest();
+  //Tests::runCoremlConvertCrossFormatTest();
+  //Tests::runCoremlConvertDeterminismTest();
+  //Tests::runCoremlConvertGoldenTest();
+  //Tests::runCoremlConvertPeakMemoryTest();
+  cout << "All CoreML converter tests passed" << endl;
+  return 0;
+#else
+  cout << "runcoremlconverttests is only available in a METAL backend build" << endl;
+  return 0;
+#endif
+}
+

--- a/cpp/command/runtests.cpp
+++ b/cpp/command/runtests.cpp
@@ -764,7 +764,7 @@ int MainCmds::runcoremlconverttests(const vector<string>& args) {
   Tests::runCoremlConvertCrossFormatTest();
   Tests::runCoremlConvertDeterminismTest();
   Tests::runCoremlConvertGoldenTest();
-  //Tests::runCoremlConvertPeakMemoryTest();
+  Tests::runCoremlConvertPeakMemoryTest();
   cout << "All CoreML converter tests passed" << endl;
   return 0;
 #else

--- a/cpp/command/runtests.cpp
+++ b/cpp/command/runtests.cpp
@@ -763,7 +763,7 @@ int MainCmds::runcoremlconverttests(const vector<string>& args) {
   Tests::runCoremlConvertSmokeTest();
   Tests::runCoremlConvertCrossFormatTest();
   Tests::runCoremlConvertDeterminismTest();
-  //Tests::runCoremlConvertGoldenTest();
+  Tests::runCoremlConvertGoldenTest();
   //Tests::runCoremlConvertPeakMemoryTest();
   cout << "All CoreML converter tests passed" << endl;
   return 0;

--- a/cpp/command/runtests.cpp
+++ b/cpp/command/runtests.cpp
@@ -762,7 +762,7 @@ int MainCmds::runcoremlconverttests(const vector<string>& args) {
 #ifdef USE_METAL_BACKEND
   Tests::runCoremlConvertSmokeTest();
   Tests::runCoremlConvertCrossFormatTest();
-  //Tests::runCoremlConvertDeterminismTest();
+  Tests::runCoremlConvertDeterminismTest();
   //Tests::runCoremlConvertGoldenTest();
   //Tests::runCoremlConvertPeakMemoryTest();
   cout << "All CoreML converter tests passed" << endl;

--- a/cpp/external/katagocoreml/src/Converter.cpp
+++ b/cpp/external/katagocoreml/src/Converter.cpp
@@ -29,9 +29,12 @@ void KataGoConverter::convert(const std::string& input_path,
         throw std::invalid_argument("max_batch_size must be >= min_batch_size or <= 0 for unlimited");
     }
 
-    // Parse KataGo model
-    KataGoParser parser(input_path);
-    KataGoModelDesc model = parser.parse();
+    // Parse KataGo model (parser + its decompressed buffer freed at end of scope)
+    KataGoModelDesc model;
+    {
+        KataGoParser parser(input_path);
+        model = parser.parse();
+    }
 
     // Determine if using FP16 precision
     bool use_fp16 = (options.compute_precision == "FLOAT16");
@@ -52,9 +55,8 @@ void KataGoConverter::convert(const std::string& input_path,
                        options.use_fp16_io);
     auto program = builder.build();
 
-    // Get weights from builder
-    auto weights = builder.getWeights();
-    std::vector<WeightEntry> weights_copy(weights.begin(), weights.end());
+    // Serialize directly from the builder's weight views (no copy).
+    std::vector<WeightEntry>& weights = builder.getWeightsMutable();
 
     // Update options with model metadata for serialization
     ConversionOptions final_options = options;
@@ -82,7 +84,7 @@ void KataGoConverter::convert(const std::string& input_path,
 
     // Serialize to .mlpackage
     CoreMLSerializer serializer(final_options.specification_version);
-    serializer.serialize(program.get(), weights_copy, output_path, final_options);
+    serializer.serialize(program.get(), weights, output_path, final_options);
 }
 
 ModelInfo KataGoConverter::getModelInfo(const std::string& input_path) {

--- a/cpp/external/katagocoreml/src/builder/MILBuilder.cpp
+++ b/cpp/external/katagocoreml/src/builder/MILBuilder.cpp
@@ -212,9 +212,23 @@ void MILBuilder::addConstOp(CoreML::Specification::MILSpec::Block* block,
                             const std::string& name,
                             const std::vector<float>& data,
                             const std::vector<int64_t>& shape) {
-    // Register weight for blob storage
+    // Register weight for blob storage (non-owning view into the model)
     m_ops.registerWeight(name, data, shape);
+    emitConstOp(block, name, shape);
+}
 
+void MILBuilder::addOwnedConstOp(CoreML::Specification::MILSpec::Block* block,
+                                 const std::string& name,
+                                 std::vector<float>&& data,
+                                 const std::vector<int64_t>& shape) {
+    // Register derived weight; KataGoOps takes ownership of the buffer
+    m_ops.registerOwnedWeight(name, std::move(data), shape);
+    emitConstOp(block, name, shape);
+}
+
+void MILBuilder::emitConstOp(CoreML::Specification::MILSpec::Block* block,
+                             const std::string& name,
+                             const std::vector<int64_t>& shape) {
     // Add const operation
     auto* op = block->add_operations();
     op->set_type("const");
@@ -958,7 +972,7 @@ void MILBuilder::addLinearOp(CoreML::Specification::MILSpec::Block* block,
 
     // Add transposed weight constant with shape [out_channels, in_channels]
     std::vector<int64_t> transposed_shape = {static_cast<int64_t>(out_ch), static_cast<int64_t>(in_ch)};
-    addConstOp(block, weight_name, transposed_weights, transposed_shape);
+    addOwnedConstOp(block, weight_name, std::move(transposed_weights), transposed_shape);
 
     // Add bias constant
     std::vector<int64_t> bias_shape = {static_cast<int64_t>(bias.num_channels)};

--- a/cpp/external/katagocoreml/src/builder/MILBuilder.hpp
+++ b/cpp/external/katagocoreml/src/builder/MILBuilder.hpp
@@ -29,9 +29,6 @@ public:
     /// @return Unique pointer to MIL Program protobuf
     std::unique_ptr<CoreML::Specification::MILSpec::Program> build();
 
-    /// Get weight entries for blob serialization
-    const std::vector<WeightEntry>& getWeights() const { return m_ops.getWeights(); }
-
     /// Get weight entries for blob serialization (mutable; serialization sets blob_offset)
     std::vector<WeightEntry>& getWeightsMutable() { return m_ops.getWeightsMutable(); }
 

--- a/cpp/external/katagocoreml/src/builder/MILBuilder.hpp
+++ b/cpp/external/katagocoreml/src/builder/MILBuilder.hpp
@@ -80,6 +80,15 @@ private:
                     const std::vector<float>& data,
                     const std::vector<int64_t>& shape);
 
+    void addOwnedConstOp(CoreML::Specification::MILSpec::Block* block,
+                         const std::string& name,
+                         std::vector<float>&& data,
+                         const std::vector<int64_t>& shape);
+
+    void emitConstOp(CoreML::Specification::MILSpec::Block* block,
+                     const std::string& name,
+                     const std::vector<int64_t>& shape);
+
     void addIntArrayConstOp(CoreML::Specification::MILSpec::Block* block,
                             const std::string& name,
                             const std::vector<int32_t>& values);

--- a/cpp/external/katagocoreml/src/builder/MILBuilder.hpp
+++ b/cpp/external/katagocoreml/src/builder/MILBuilder.hpp
@@ -32,6 +32,9 @@ public:
     /// Get weight entries for blob serialization
     const std::vector<WeightEntry>& getWeights() const { return m_ops.getWeights(); }
 
+    /// Get weight entries for blob serialization (mutable; serialization sets blob_offset)
+    std::vector<WeightEntry>& getWeightsMutable() { return m_ops.getWeightsMutable(); }
+
     /// Get board dimensions
     int getBoardXSize() const { return m_board_x_size; }
     int getBoardYSize() const { return m_board_y_size; }

--- a/cpp/external/katagocoreml/src/builder/Operations.cpp
+++ b/cpp/external/katagocoreml/src/builder/Operations.cpp
@@ -17,9 +17,25 @@ std::string KataGoOps::registerWeight(const std::string& name,
                                        const std::vector<int64_t>& shape) {
     WeightEntry entry;
     entry.name = name;
-    entry.data = data;
+    entry.data = data.data();
+    entry.count = data.size();
     entry.shape = shape;
-    entry.blob_offset = 0;  // Will be set during serialization
+    entry.blob_offset = 0;
+    m_weights.push_back(std::move(entry));
+    return name;
+}
+
+std::string KataGoOps::registerOwnedWeight(const std::string& name,
+                                            std::vector<float>&& data,
+                                            const std::vector<int64_t>& shape) {
+    m_owned.push_back(std::move(data));
+    const std::vector<float>& stored = m_owned.back();
+    WeightEntry entry;
+    entry.name = name;
+    entry.data = stored.data();
+    entry.count = stored.size();
+    entry.shape = shape;
+    entry.blob_offset = 0;
     m_weights.push_back(std::move(entry));
     return name;
 }

--- a/cpp/external/katagocoreml/src/builder/Operations.hpp
+++ b/cpp/external/katagocoreml/src/builder/Operations.hpp
@@ -5,15 +5,18 @@
 
 #include "../types/KataGoTypes.hpp"
 #include <cmath>
+#include <deque>
 #include <string>
 #include <vector>
 
 namespace katagocoreml {
 
-/// Weight entry for blob file storage
+/// Weight entry for blob file storage. `data`/`count` are a NON-OWNING view into
+/// the live KataGoModelDesc (or into KataGoOps::m_owned for derived tensors).
 struct WeightEntry {
     std::string name;
-    std::vector<float> data;
+    const float* data = nullptr;
+    size_t count = 0;
     std::vector<int64_t> shape;
     uint64_t blob_offset = 0;  // Set during serialization
 };
@@ -51,10 +54,16 @@ public:
     /// Get precomputed mask constants
     const MaskConstants& getMaskConstants() const { return m_mask_constants; }
 
-    /// Register a weight tensor and return its reference name
+    /// Register a weight that lives in the model (stored as a non-owning view).
     std::string registerWeight(const std::string& name,
                                const std::vector<float>& data,
                                const std::vector<int64_t>& shape);
+
+    /// Register a derived/temporary weight; KataGoOps takes ownership so the
+    /// view stays valid through serialization.
+    std::string registerOwnedWeight(const std::string& name,
+                                    std::vector<float>&& data,
+                                    const std::vector<int64_t>& shape);
 
     /// Get all registered weights
     const std::vector<WeightEntry>& getWeights() const { return m_weights; }
@@ -71,6 +80,7 @@ private:
     bool m_optimize_identity_mask;
     MaskConstants m_mask_constants;
     std::vector<WeightEntry> m_weights;
+    std::deque<std::vector<float>> m_owned;
     int m_op_counter = 0;
 };
 

--- a/cpp/external/katagocoreml/src/builder/Operations.hpp
+++ b/cpp/external/katagocoreml/src/builder/Operations.hpp
@@ -65,9 +65,6 @@ public:
                                     std::vector<float>&& data,
                                     const std::vector<int64_t>& shape);
 
-    /// Get all registered weights
-    const std::vector<WeightEntry>& getWeights() const { return m_weights; }
-
     /// Get all registered weights (mutable; serialization sets blob_offset)
     std::vector<WeightEntry>& getWeightsMutable() { return m_weights; }
 

--- a/cpp/external/katagocoreml/src/builder/Operations.hpp
+++ b/cpp/external/katagocoreml/src/builder/Operations.hpp
@@ -68,6 +68,9 @@ public:
     /// Get all registered weights
     const std::vector<WeightEntry>& getWeights() const { return m_weights; }
 
+    /// Get all registered weights (mutable; serialization sets blob_offset)
+    std::vector<WeightEntry>& getWeightsMutable() { return m_weights; }
+
     /// Clear all registered weights
     void clearWeights() { m_weights.clear(); }
 

--- a/cpp/external/katagocoreml/src/parser/KataGoParser.cpp
+++ b/cpp/external/katagocoreml/src/parser/KataGoParser.cpp
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
-#include <fstream>
 #include <stdexcept>
 #include <zlib.h>
 
@@ -51,12 +50,6 @@ int KataGoParser::peekByte() {
         if(!refill()) return -1;
     }
     return (int)m_refill[m_refillPos];
-}
-
-int KataGoParser::getByte() {
-    int c = peekByte();
-    if(c >= 0) m_refillPos++;
-    return c;
 }
 
 void KataGoParser::readExact(uint8_t* dst, size_t n, const std::string& name) {

--- a/cpp/external/katagocoreml/src/parser/KataGoParser.cpp
+++ b/cpp/external/katagocoreml/src/parser/KataGoParser.cpp
@@ -30,54 +30,47 @@ bool KataGoParser::isVersionSupported(int version) {
 }
 
 // ============================================================================
-// File Loading
+// Stream Primitives
 // ============================================================================
 
-void KataGoParser::loadFile() {
-    // Check if gzip compressed
-    bool is_gzip = false;
-    if (m_model_path.size() >= 3) {
-        std::string ext = m_model_path.substr(m_model_path.size() - 3);
-        is_gzip = (ext == ".gz");
+bool KataGoParser::refill() {
+    if(m_gz == nullptr) return false;
+    int n = gzread(m_gz, m_refill.data(), (unsigned)m_refill.size());
+    if(n < 0) {
+        int errnum;
+        const char* errmsg = gzerror(m_gz, &errnum);
+        throw std::runtime_error("Error reading gzip stream: " + std::string(errmsg));
     }
+    m_refillPos = 0;
+    m_refillLen = (size_t)n;
+    return n > 0;
+}
 
-    if (is_gzip) {
-        // Read gzipped file
-        gzFile gz = gzopen(m_model_path.c_str(), "rb");
-        if (!gz) {
-            throw std::runtime_error("Cannot open gzip file: " + m_model_path);
+int KataGoParser::peekByte() {
+    if(m_refillPos >= m_refillLen) {
+        if(!refill()) return -1;
+    }
+    return (int)m_refill[m_refillPos];
+}
+
+int KataGoParser::getByte() {
+    int c = peekByte();
+    if(c >= 0) m_refillPos++;
+    return c;
+}
+
+void KataGoParser::readExact(uint8_t* dst, size_t n, const std::string& name) {
+    size_t got = 0;
+    while(got < n) {
+        if(m_refillPos >= m_refillLen) {
+            if(!refill())
+                throw std::runtime_error(name + ": unexpected EOF in binary block");
         }
-
-        // Read in chunks
-        m_buffer.clear();
-        std::vector<uint8_t> chunk(1024 * 1024);  // 1MB chunks
-        int bytes_read;
-        while ((bytes_read = gzread(gz, chunk.data(), static_cast<unsigned>(chunk.size()))) > 0) {
-            m_buffer.insert(m_buffer.end(), chunk.begin(), chunk.begin() + bytes_read);
-        }
-
-        if (bytes_read < 0) {
-            int errnum;
-            const char* errmsg = gzerror(gz, &errnum);
-            gzclose(gz);
-            throw std::runtime_error("Error reading gzip file: " + std::string(errmsg));
-        }
-
-        gzclose(gz);
-    } else {
-        // Read regular file
-        std::ifstream file(m_model_path, std::ios::binary | std::ios::ate);
-        if (!file) {
-            throw std::runtime_error("Cannot open file: " + m_model_path);
-        }
-
-        std::streamsize size = file.tellg();
-        file.seekg(0, std::ios::beg);
-
-        m_buffer.resize(static_cast<size_t>(size));
-        if (!file.read(reinterpret_cast<char*>(m_buffer.data()), size)) {
-            throw std::runtime_error("Error reading file: " + m_model_path);
-        }
+        size_t avail = m_refillLen - m_refillPos;
+        size_t take = std::min(avail, n - got);
+        std::memcpy(dst + got, m_refill.data() + m_refillPos, take);
+        m_refillPos += take;
+        got += take;
     }
 }
 
@@ -86,16 +79,25 @@ void KataGoParser::loadFile() {
 // ============================================================================
 
 KataGoModelDesc KataGoParser::parse() {
-    loadFile();
-    m_pos = 0;
-
-    // Detect if binary format (check for @BIN@ marker)
-    const std::string bin_marker = "@BIN@";
-    auto it = std::search(m_buffer.begin(), m_buffer.end(),
-                          bin_marker.begin(), bin_marker.end());
-    m_binary_floats = (it != m_buffer.end());
-
-    return parseModel();
+    m_gz = gzopen(m_model_path.c_str(), "rb");
+    if(m_gz == nullptr)
+        throw std::runtime_error("Cannot open file: " + m_model_path);
+    m_refill.resize(1024 * 1024);
+    m_refillPos = 0;
+    m_refillLen = 0;
+    m_formatDetected = false;   // decided at first readFloats
+    m_binary_floats = true;
+    KataGoModelDesc model;
+    try {
+        model = parseModel();
+    } catch(...) {
+        gzclose(m_gz);
+        m_gz = nullptr;
+        throw;
+    }
+    gzclose(m_gz);
+    m_gz = nullptr;
+    return model;
 }
 
 // ============================================================================
@@ -103,24 +105,20 @@ KataGoModelDesc KataGoParser::parse() {
 // ============================================================================
 
 void KataGoParser::skipWhitespace() {
-    while (m_pos < m_buffer.size()) {
-        char c = static_cast<char>(m_buffer[m_pos]);
-        if (c != ' ' && c != '\t' && c != '\n' && c != '\r') {
-            break;
-        }
-        m_pos++;
+    int c;
+    while((c = peekByte()) >= 0) {
+        if(c != ' ' && c != '\t' && c != '\n' && c != '\r') break;
+        m_refillPos++;
     }
 }
 
 void KataGoParser::readUntilWhitespace(std::string& out) {
     out.clear();
-    while (m_pos < m_buffer.size()) {
-        char c = static_cast<char>(m_buffer[m_pos]);
-        if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
-            break;
-        }
-        out += c;
-        m_pos++;
+    int c;
+    while((c = peekByte()) >= 0) {
+        if(c == ' ' || c == '\t' || c == '\n' || c == '\r') break;
+        out += (char)c;
+        m_refillPos++;
     }
 }
 
@@ -147,39 +145,26 @@ bool KataGoParser::readBool() {
 
 std::vector<float> KataGoParser::readFloats(size_t count, const std::string& name) {
     std::vector<float> floats(count);
+    skipWhitespace();
 
-    if (!m_binary_floats) {
-        // Text format
-        for (size_t i = 0; i < count; i++) {
-            floats[i] = readFloat();
-        }
-    } else {
-        // Binary format - find @BIN@ marker
-        while (m_pos < m_buffer.size()) {
-            if (m_buffer[m_pos] == '@') {
-                break;
-            }
-            m_pos++;
-        }
-
-        // Check for @BIN@ header
-        if (m_pos + 5 > m_buffer.size() ||
-            std::memcmp(&m_buffer[m_pos], "@BIN@", 5) != 0) {
-            throw std::runtime_error(name + ": expected @BIN@ marker for binary float block");
-        }
-        m_pos += 5;
-
-        // Read binary floats (little-endian)
-        size_t num_bytes = count * 4;
-        if (m_pos + num_bytes > m_buffer.size()) {
-            throw std::runtime_error(name + ": not enough bytes for " + std::to_string(count) + " floats");
-        }
-
-        // Copy as little-endian float32
-        std::memcpy(floats.data(), &m_buffer[m_pos], num_bytes);
-        m_pos += num_bytes;
+    if(!m_formatDetected) {
+        m_binary_floats = (peekByte() == '@');
+        m_formatDetected = true;
     }
 
+    if(!m_binary_floats) {
+        for(size_t i = 0; i < count; i++)
+            floats[i] = readFloat();
+        return floats;
+    }
+
+    // Binary: consume the "@BIN@" marker, then read count*4 raw bytes.
+    char marker[5];
+    readExact(reinterpret_cast<uint8_t*>(marker), 5, name);
+    if(std::memcmp(marker, "@BIN@", 5) != 0)
+        throw std::runtime_error(name + ": expected @BIN@ marker for binary float block");
+
+    readExact(reinterpret_cast<uint8_t*>(floats.data()), count * 4, name);
     return floats;
 }
 

--- a/cpp/external/katagocoreml/src/parser/KataGoParser.hpp
+++ b/cpp/external/katagocoreml/src/parser/KataGoParser.hpp
@@ -42,7 +42,6 @@ private:
     // Stream primitives
     bool refill();                   // returns false at EOF
     int  peekByte();                 // -1 at EOF
-    int  getByte();                  // -1 at EOF
     void readExact(uint8_t* dst, size_t n, const std::string& name);
 
     // Low-level reading functions

--- a/cpp/external/katagocoreml/src/parser/KataGoParser.hpp
+++ b/cpp/external/katagocoreml/src/parser/KataGoParser.hpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <string>
 #include <vector>
+#include <zlib.h>
 
 namespace katagocoreml {
 
@@ -31,9 +32,18 @@ public:
 
 private:
     std::string m_model_path;
-    std::vector<uint8_t> m_buffer;
-    size_t m_pos = 0;
+    gzFile m_gz = nullptr;
+    std::vector<uint8_t> m_refill;   // bounded refill buffer (~1 MB)
+    size_t m_refillPos = 0;          // read cursor within m_refill
+    size_t m_refillLen = 0;          // valid bytes in m_refill
     bool m_binary_floats = true;
+    bool m_formatDetected = false;
+
+    // Stream primitives
+    bool refill();                   // returns false at EOF
+    int  peekByte();                 // -1 at EOF
+    int  getByte();                  // -1 at EOF
+    void readExact(uint8_t* dst, size_t n, const std::string& name);
 
     // Low-level reading functions
     void readUntilWhitespace(std::string& out);
@@ -65,9 +75,6 @@ private:
 
     // Main model parsing
     KataGoModelDesc parseModel();
-
-    // Helper to load file (handles gzip)
-    void loadFile();
 };
 
 }  // namespace katagocoreml

--- a/cpp/external/katagocoreml/src/serializer/CoreMLSerializer.cpp
+++ b/cpp/external/katagocoreml/src/serializer/CoreMLSerializer.cpp
@@ -12,6 +12,8 @@
 #include <stdexcept>
 #include <filesystem>
 #include <unordered_map>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <google/protobuf/io/coded_stream.h>
 
 namespace katagocoreml {
 
@@ -230,8 +232,13 @@ void CoreMLSerializer::createPackage(const std::string& output_path,
         if (!out) {
             throw std::runtime_error("Failed to create temp model file");
         }
-        if (!model->SerializeToOstream(&out)) {
-            throw std::runtime_error("Failed to serialize model spec");
+        {
+            google::protobuf::io::OstreamOutputStream zos(&out);
+            google::protobuf::io::CodedOutputStream cos(&zos);
+            cos.SetSerializationDeterministic(true);
+            if (!model->SerializeToCodedStream(&cos)) {
+                throw std::runtime_error("Failed to serialize model spec");
+            }
         }
     }
 

--- a/cpp/external/katagocoreml/src/serializer/WeightSerializer.cpp
+++ b/cpp/external/katagocoreml/src/serializer/WeightSerializer.cpp
@@ -17,18 +17,18 @@ size_t WeightSerializer::serialize(std::vector<WeightEntry>& weights,
     for (auto& entry : weights) {
         if (use_fp16) {
             // Convert FP32 weights to FP16
-            std::vector<MILBlob::Fp16> fp16_data(entry.data.size());
-            for (size_t i = 0; i < entry.data.size(); ++i) {
+            std::vector<MILBlob::Fp16> fp16_data(entry.count);
+            for (size_t i = 0; i < entry.count; ++i) {
                 fp16_data[i] = MILBlob::Fp16::FromFloat(entry.data[i]);
             }
             MILBlob::Util::Span<const MILBlob::Fp16> span(fp16_data.data(), fp16_data.size());
             entry.blob_offset = writer.WriteData(span);
-            total_bytes += entry.data.size() * sizeof(MILBlob::Fp16);
+            total_bytes += entry.count * sizeof(MILBlob::Fp16);
         } else {
             // Write FP32 weights
-            MILBlob::Util::Span<const float> span(entry.data.data(), entry.data.size());
+            MILBlob::Util::Span<const float> span(entry.data, entry.count);
             entry.blob_offset = writer.WriteData(span);
-            total_bytes += entry.data.size() * sizeof(float);
+            total_bytes += entry.count * sizeof(float);
         }
     }
 

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -128,6 +128,8 @@ static int handleSubcommand(const string& subcommand, const vector<string>& args
     return MainCmds::runnnevalcanarytests(subArgs);
   else if(subcommand == "runconfigtests")
     return MainCmds::runconfigtests(subArgs);
+  else if(subcommand == "runcoremlconverttests")
+    return MainCmds::runcoremlconverttests(subArgs);
   else if(subcommand == "samplesgfs")
     return MainCmds::samplesgfs(subArgs);
   else if(subcommand == "dataminesgfs")

--- a/cpp/main.h
+++ b/cpp/main.h
@@ -35,6 +35,7 @@ namespace MainCmds {
   int runownershipspeedtest(const std::vector<std::string>& args);
   int runsleeptest(const std::vector<std::string>& args);
   int runconfigtests(const std::vector<std::string>& args);
+  int runcoremlconverttests(const std::vector<std::string>& args);
 
   int samplesgfs(const std::vector<std::string>& args);
   int dataminesgfs(const std::vector<std::string>& args);

--- a/cpp/neuralnet/desc.cpp
+++ b/cpp/neuralnet/desc.cpp
@@ -1779,6 +1779,75 @@ void ModelDesc::applyScale8ToReduceActivations() {
   postProcessParams.outputScaleMultiplier *= 8.0f;
 }
 
+static void releaseVec(std::vector<float>& v) { std::vector<float>().swap(v); }
+
+static void releaseConv(ConvLayerDesc& c) { releaseVec(c.weights); }
+
+static void releaseBN(BatchNormLayerDesc& b) {
+  releaseVec(b.mean); releaseVec(b.variance); releaseVec(b.scale);
+  releaseVec(b.bias); releaseVec(b.mergedScale); releaseVec(b.mergedBias);
+}
+
+static void releaseMatMul(MatMulLayerDesc& m) { releaseVec(m.weights); }
+static void releaseMatBias(MatBiasLayerDesc& m) { releaseVec(m.weights); }
+
+static void releaseResidual(ResidualBlockDesc& b) {
+  releaseBN(b.preBN); releaseConv(b.regularConv);
+  releaseBN(b.midBN); releaseConv(b.finalConv);
+}
+
+static void releaseGPool(GlobalPoolingResidualBlockDesc& b) {
+  releaseBN(b.preBN); releaseConv(b.regularConv); releaseConv(b.gpoolConv);
+  releaseBN(b.gpoolBN); releaseMatMul(b.gpoolToBiasMul);
+  releaseBN(b.midBN); releaseConv(b.finalConv);
+}
+
+static void releaseBlocks(std::vector<std::pair<int, unique_ptr_void>>& blocks);
+
+static void releaseNested(NestedBottleneckResidualBlockDesc& b) {
+  releaseBN(b.preBN); releaseConv(b.preConv);
+  releaseBlocks(b.blocks);
+  releaseBN(b.postBN); releaseConv(b.postConv);
+}
+
+static void releaseBlocks(std::vector<std::pair<int, unique_ptr_void>>& blocks) {
+  for(size_t i = 0; i < blocks.size(); i++) {
+    if(blocks[i].first == ORDINARY_BLOCK_KIND)
+      releaseResidual(*(ResidualBlockDesc*)blocks[i].second.get());
+    else if(blocks[i].first == GLOBAL_POOLING_BLOCK_KIND)
+      releaseGPool(*(GlobalPoolingResidualBlockDesc*)blocks[i].second.get());
+    else if(blocks[i].first == NESTED_BOTTLENECK_BLOCK_KIND)
+      releaseNested(*(NestedBottleneckResidualBlockDesc*)blocks[i].second.get());
+    else
+      testAssert(false);
+  }
+}
+
+static void releaseSGFEncoder(SGFMetadataEncoderDesc& e) {
+  releaseMatMul(e.mul1); releaseMatBias(e.bias1);
+  releaseMatMul(e.mul2); releaseMatBias(e.bias2);
+  releaseMatMul(e.mul3);
+}
+
+void ModelDesc::releaseWeights() {
+  releaseConv(trunk.initialConv);
+  releaseMatMul(trunk.initialMatMul);
+  if(trunk.metaEncoderVersion > 0)
+    releaseSGFEncoder(trunk.sgfMetadataEncoder);
+  releaseBlocks(trunk.blocks);
+  releaseBN(trunk.trunkTipBN);
+  releaseConv(policyHead.p1Conv); releaseConv(policyHead.g1Conv);
+  releaseBN(policyHead.g1BN); releaseMatMul(policyHead.gpoolToBiasMul);
+  releaseBN(policyHead.p1BN); releaseConv(policyHead.p2Conv);
+  releaseMatMul(policyHead.gpoolToPassMul); releaseMatBias(policyHead.gpoolToPassBias);
+  releaseMatMul(policyHead.gpoolToPassMul2);
+  releaseConv(valueHead.v1Conv); releaseBN(valueHead.v1BN);
+  releaseMatMul(valueHead.v2Mul); releaseMatBias(valueHead.v2Bias);
+  releaseMatMul(valueHead.v3Mul); releaseMatBias(valueHead.v3Bias);
+  releaseMatMul(valueHead.sv3Mul); releaseMatBias(valueHead.sv3Bias);
+  releaseConv(valueHead.vOwnershipConv);
+}
+
 struct NonCopyingStreamBuf : public std::streambuf
 {
   NonCopyingStreamBuf(string& str) {

--- a/cpp/neuralnet/desc.h
+++ b/cpp/neuralnet/desc.h
@@ -388,6 +388,11 @@ struct ModelDesc {
   //Fills supported with true if desiredRules itself was exactly supported, false if some modifications had to be made.
   Rules getSupportedRules(const Rules& desiredRules, bool& supported) const;
 
+  // Frees all weight arrays (conv/matmul/bias/batchnorm), keeping scalar shape
+  // metadata intact. Safe once weights are no longer needed (e.g. CoreML/ANE
+  // inference, which reads weights from the compiled .mlmodelc).
+  void releaseWeights();
+
 };
 
 #endif  // #ifndef DESC_H

--- a/cpp/neuralnet/metalbackend.cpp
+++ b/cpp/neuralnet/metalbackend.cpp
@@ -461,6 +461,15 @@ static swift::Optional<KataGoSwift::CoreMLComputeHandle> convertAndCreateCoreMLO
   bool useFP16 = (context->useFP16Mode != enabled_t::False);
   bool optimizeMask = requireExactNNLen;
 
+  // ANE path only (this function runs solely for METAL_MUX_ANE): the compiled
+  // .mlmodelc carries the weights; the engine's ModelDesc weight arrays are
+  // never read again here. Free them to drop W1 from the conversion peak and
+  // from steady-state RSS. releaseWeights() clears only weight vectors; the
+  // scalar dims read below (and by the ComputeHandle ctor / InputBuffers) stay
+  // valid. NOTE: assumes ANE and GPU/MPSGraph are not mixed for one LoadedModel
+  // (iOS = ANE-only, macOS = GPU-only).
+  const_cast<LoadedModel*>(loadedModel)->modelDesc.releaseWeights();
+
   // Try the cache-aware bridge path first (Task 19).
   // invokeCoreMLBridge returns nil when katago_coreml_bridge is not yet registered
   // (e.g., before KataGoInterface.registerCoreMLBridge() is called), in which case

--- a/cpp/tests/testcoremlconvert.cpp
+++ b/cpp/tests/testcoremlconvert.cpp
@@ -1,0 +1,91 @@
+#include "../tests/tests.h"
+
+#ifdef USE_METAL_BACKEND
+
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <sys/resource.h>
+#include <zlib.h>
+
+#include "../core/sha2.h"
+#include "katagocoreml/KataGoConverter.hpp"
+
+using namespace std;
+
+namespace {
+
+// (staged for runCoremlConvertPeakMemoryTest)
+static size_t peakRssBytes() {
+  struct rusage usage;
+  if(getrusage(RUSAGE_SELF, &usage) != 0)
+    return 0;
+  return (size_t)usage.ru_maxrss;
+}
+
+static string sha256OfFile(const string& path) {
+  ifstream in(path, ios::binary);
+  if(!in)
+    throw runtime_error("sha256OfFile: cannot open " + path);
+  vector<uint8_t> bytes((istreambuf_iterator<char>(in)), istreambuf_iterator<char>());
+  char hash[65];
+  SHA2::get256(bytes.data(), bytes.size(), hash);
+  return string(hash);
+}
+
+// (staged for runCoremlConvertPeakMemoryTest)
+static size_t gzDecompressedSize(const string& path) {
+  gzFile gz = gzopen(path.c_str(), "rb");
+  if(!gz)
+    throw runtime_error("gzDecompressedSize: cannot open " + path);
+  vector<uint8_t> chunk(1024 * 1024);
+  size_t total = 0;
+  int n;
+  while((n = gzread(gz, chunk.data(), (unsigned)chunk.size())) > 0)
+    total += (size_t)n;
+  if(n < 0) {
+    int errnum;
+    const char* msg = gzerror(gz, &errnum);
+    gzclose(gz);
+    throw runtime_error("gzDecompressedSize: read error on " + path + ": " + string(msg));
+  }
+  gzclose(gz);
+  return total;
+}
+
+static string convertToTemp(
+  const string& modelPath, const string& tag, int boardX, int boardY,
+  bool fp16, bool optimizeMask, string& outPackageDir
+) {
+  outPackageDir = "/tmp/katago_convtest_" + tag + ".mlpackage";
+  katagocoreml::ConversionOptions opts;
+  opts.board_x_size = boardX;
+  opts.board_y_size = boardY;
+  opts.compute_precision = fp16 ? "FLOAT16" : "FLOAT32";
+  opts.optimize_identity_mask = optimizeMask;
+  opts.min_batch_size = 1;
+  opts.max_batch_size = 8;
+  std::error_code ec;
+  std::filesystem::remove_all(outPackageDir, ec);
+  katagocoreml::KataGoConverter::convert(modelPath, outPackageDir, opts);
+  return outPackageDir + "/Data/com.apple.CoreML/weights/weight.bin";
+}
+
+} // namespace
+
+void Tests::runCoremlConvertSmokeTest() {
+  cout << "Running runCoremlConvertSmokeTest" << endl;
+  const string model = "tests/models/g170-b6c96-s175395328-d26788732.bin.gz";
+  string pkg;
+  string weightBin = convertToTemp(model, "smoke", 19, 19, true, false, pkg);
+  ifstream check(weightBin, ios::binary);
+  testAssert(check.good());
+  cout << "  weight.bin sha256 = " << sha256OfFile(weightBin) << endl;
+  cout << "runCoremlConvertSmokeTest passed" << endl;
+}
+
+#endif // USE_METAL_BACKEND

--- a/cpp/tests/testcoremlconvert.cpp
+++ b/cpp/tests/testcoremlconvert.cpp
@@ -122,4 +122,27 @@ void Tests::runCoremlConvertDeterminismTest() {
   cout << "runCoremlConvertDeterminismTest passed" << endl;
 }
 
+void Tests::runCoremlConvertGoldenTest() {
+  cout << "Running runCoremlConvertGoldenTest" << endl;
+  // Golden hashes from the converter for g170-b6c96, FP16, 19x19,
+  // optimize_identity_mask=false. model.mlmodel is byte-stable thanks to
+  // deterministic protobuf serialization. DO NOT bump katagocoreml VERSION.
+  const string GOLDEN_WEIGHT_SHA = "4dd744f0907d37bf45287ebf765a124c472f61116dc753bdc48fb6ab3a5599d9";
+  const string GOLDEN_MODEL_SHA  = "923f7ed7b2eba03eaca58068f3a90195444278e956a4f5f361df6dd75ba23316";
+
+  const string model = "tests/models/g170-b6c96-s175395328-d26788732.bin.gz";
+  string pkg;
+  string weightBin = convertToTemp(model, "golden", 19, 19, true, false, pkg);
+  string modelSpec = pkg + "/Data/com.apple.CoreML/model.mlmodel";
+
+  string weightSha = sha256OfFile(weightBin);
+  string modelSha = sha256OfFile(modelSpec);
+  cout << "  weight.bin sha256 = " << weightSha << endl;
+  cout << "  model.mlmodel sha256 = " << modelSha << endl;
+
+  testAssert(weightSha == GOLDEN_WEIGHT_SHA);
+  testAssert(modelSha == GOLDEN_MODEL_SHA);
+  cout << "runCoremlConvertGoldenTest passed" << endl;
+}
+
 #endif // USE_METAL_BACKEND

--- a/cpp/tests/testcoremlconvert.cpp
+++ b/cpp/tests/testcoremlconvert.cpp
@@ -88,4 +88,28 @@ void Tests::runCoremlConvertSmokeTest() {
   cout << "runCoremlConvertSmokeTest passed" << endl;
 }
 
+void Tests::runCoremlConvertCrossFormatTest() {
+  cout << "Running runCoremlConvertCrossFormatTest" << endl;
+  const string binModel = "tests/models/g170-b6c96-s175395328-d26788732.bin.gz";
+  const string txtModel = "tests/models/g170-b6c96-s175395328-d26788732.txt.gz";
+  // Full matrix: precision x board size x optimize_identity_mask. For identical
+  // options, the binary-stream parser and the text parser must agree exactly.
+  for(bool fp16 : {true, false}) {
+    for(auto bs : { std::pair<int,int>{19, 19}, std::pair<int,int>{9, 9} }) {
+      for(bool mask : {false, true}) {
+        string tag = string(fp16 ? "fp16" : "fp32") + "_" + to_string(bs.first)
+                   + "_" + (mask ? "mask" : "nomask");
+        string binPkg, txtPkg;
+        string binWeights = convertToTemp(binModel, "xfmt_bin_" + tag, bs.first, bs.second, fp16, mask, binPkg);
+        string txtWeights = convertToTemp(txtModel, "xfmt_txt_" + tag, bs.first, bs.second, fp16, mask, txtPkg);
+        string binHash = sha256OfFile(binWeights);
+        string txtHash = sha256OfFile(txtWeights);
+        cout << "  " << tag << ": bin=" << binHash << " txt=" << txtHash << endl;
+        testAssert(binHash == txtHash);
+      }
+    }
+  }
+  cout << "runCoremlConvertCrossFormatTest passed" << endl;
+}
+
 #endif // USE_METAL_BACKEND

--- a/cpp/tests/testcoremlconvert.cpp
+++ b/cpp/tests/testcoremlconvert.cpp
@@ -1,6 +1,6 @@
 #include "../tests/tests.h"
 
-#ifdef USE_METAL_BACKEND
+#ifdef KATAGO_COREML_CONVERT_TESTS
 
 #include <cstdint>
 #include <cstdlib>
@@ -173,4 +173,4 @@ void Tests::runCoremlConvertPeakMemoryTest() {
   cout << "runCoremlConvertPeakMemoryTest passed" << endl;
 }
 
-#endif // USE_METAL_BACKEND
+#endif // KATAGO_COREML_CONVERT_TESTS

--- a/cpp/tests/testcoremlconvert.cpp
+++ b/cpp/tests/testcoremlconvert.cpp
@@ -19,7 +19,6 @@ using namespace std;
 
 namespace {
 
-// (staged for runCoremlConvertPeakMemoryTest)
 static size_t peakRssBytes() {
   struct rusage usage;
   if(getrusage(RUSAGE_SELF, &usage) != 0)
@@ -37,7 +36,6 @@ static string sha256OfFile(const string& path) {
   return string(hash);
 }
 
-// (staged for runCoremlConvertPeakMemoryTest)
 static size_t gzDecompressedSize(const string& path) {
   gzFile gz = gzopen(path.c_str(), "rb");
   if(!gz)

--- a/cpp/tests/testcoremlconvert.cpp
+++ b/cpp/tests/testcoremlconvert.cpp
@@ -145,4 +145,32 @@ void Tests::runCoremlConvertGoldenTest() {
   cout << "runCoremlConvertGoldenTest passed" << endl;
 }
 
+void Tests::runCoremlConvertPeakMemoryTest() {
+  cout << "Running runCoremlConvertPeakMemoryTest" << endl;
+  const char* envModel = getenv("KATAGO_COREML_PEAK_MODEL");
+  bool strict = (envModel != nullptr);
+  string model = strict ? string(envModel)
+                        : string("tests/models/g170e-b10c128-s1141046784-d204142634.bin.gz");
+
+  size_t decompressed = gzDecompressedSize(model);
+  string pkg;
+  string weightBin = convertToTemp(model, "peak", 19, 19, true, false, pkg);
+  (void)weightBin;
+  size_t peak = peakRssBytes();
+
+  double ratio = (double)peak / (double)decompressed;
+  cout << "  model = " << model << endl;
+  cout << "  decompressed = " << (decompressed / (1024 * 1024)) << " MB" << endl;
+  cout << "  peak RSS     = " << (peak / (1024 * 1024)) << " MB" << endl;
+  cout << "  ratio        = " << ratio << "x" << endl;
+
+  const double R = 1.5;
+  if(strict) {
+    testAssert(ratio < R);
+  } else {
+    testAssert(peak < (size_t)2 * 1024 * 1024 * 1024);
+  }
+  cout << "runCoremlConvertPeakMemoryTest passed" << endl;
+}
+
 #endif // USE_METAL_BACKEND

--- a/cpp/tests/testcoremlconvert.cpp
+++ b/cpp/tests/testcoremlconvert.cpp
@@ -112,4 +112,14 @@ void Tests::runCoremlConvertCrossFormatTest() {
   cout << "runCoremlConvertCrossFormatTest passed" << endl;
 }
 
+void Tests::runCoremlConvertDeterminismTest() {
+  cout << "Running runCoremlConvertDeterminismTest" << endl;
+  const string model = "tests/models/g170e-b10c128-s1141046784-d204142634.bin.gz";
+  string pkgA, pkgB;
+  string a = convertToTemp(model, "det_a", 19, 19, true, false, pkgA);
+  string b = convertToTemp(model, "det_b", 19, 19, true, false, pkgB);
+  testAssert(sha256OfFile(a) == sha256OfFile(b));
+  cout << "runCoremlConvertDeterminismTest passed" << endl;
+}
+
 #endif // USE_METAL_BACKEND

--- a/cpp/tests/tests.h
+++ b/cpp/tests/tests.h
@@ -112,6 +112,13 @@ namespace Tests {
 
   //testbook.cpp
   void runBookTests();
+
+  //testcoremlconvert.cpp (METAL backend only)
+  void runCoremlConvertSmokeTest();
+  void runCoremlConvertCrossFormatTest();
+  void runCoremlConvertDeterminismTest();
+  void runCoremlConvertGoldenTest();
+  void runCoremlConvertPeakMemoryTest();
 }
 
 namespace TestCommon {

--- a/docs/superpowers/plans/2026-05-30-reduce-conversion-peak-memory.md
+++ b/docs/superpowers/plans/2026-05-30-reduce-conversion-peak-memory.md
@@ -1,0 +1,1056 @@
+# Reduce On-Device CoreML Conversion Peak Memory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut the one-time `bin.gz → CoreML` conversion peak memory so the b40c768nbt Official network loads without an OOM (jetsam) kill on a 4 GB iOS device.
+
+**Architecture:** Five independent levers on the `katagocoreml` C++ converter + the Metal backend + app entitlements, fronted by a new `./katago runcoremlconverttests` test subcommand (built only under the METAL backend) that measures conversion peak RSS and locks output byte-equivalence. Levers: A1 stop the 3× FP32 weight duplication (weights become non-owning views), A2 stream the gzip parse (no full decompressed buffer), A3 free the engine's ANE-dead `modelDesc` weights, A4 add the increased-memory-limit entitlement. A5 (full layer-streaming) is deferred unless on-device measurement after A1–A4 still doesn't fit.
+
+**Tech Stack:** C++17 (`cpp/external/katagocoreml`, `cpp/neuralnet`), KataGo's custom `Tests::` harness (`./katago <subcommand>`), CMake + Ninja METAL build, `getrusage` for RSS, `SHA2::get256` for golden hashes, an Apple `.entitlements` plist.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-reduce-conversion-peak-memory-design.md`
+
+---
+
+## Key facts the engineer must know
+
+- **`katagocoreml` is compiled ONLY under the METAL backend.** `cpp/CMakeLists.txt` does `add_subdirectory(external/katagocoreml)` inside the METAL branch. All converter tests therefore live behind `#ifdef USE_METAL_BACKEND` and run only in a METAL build.
+- **Build + run commands** (run from the `cpp/` directory, which makes `tests/models/...` paths resolve):
+  ```bash
+  cd /Users/chinchangyang/Code/KataGo-ios-dev/cpp
+  cmake . -G Ninja -DUSE_BACKEND=METAL -DNO_GIT_REVISION=1   # first time / after CMake edits
+  ninja                                                       # incremental rebuild
+  ./katago runcoremlconverttests                              # run the converter tests
+  ```
+  After the first successful `cmake`, only `ninja` is needed for rebuilds.
+- **`getrusage(RUSAGE_SELF).ru_maxrss` is in BYTES on macOS** (KB on Linux). The peak is process-lifetime maximum and monotonic, which is why the peak test lives in its **own** subcommand that does nothing else first.
+- **The committed test nets are tiny** (`g170-b6c96` ≈ 3.6 MB, `g170e-b10c128`). They give a strong *correctness* signal but a weak *peak-memory* signal (process baseline dominates). The strict peak-ratio assertion only bites on a large net supplied locally via the `KATAGO_COREML_PEAK_MODEL` env var (point it at the real b40c768). Without that env var the peak test logs and applies only a loose sanity bound.
+- **The converter is deterministic** and these levers must produce **byte-identical** `weight.bin` + `model.mlmodel`. Do NOT bump `katagocoreml`'s `VERSION` (it is embedded in `model.mlmodel` metadata and would change the golden hash).
+- **Fixtures** (relative to `cpp/`):
+  - `tests/models/g170-b6c96-s175395328-d26788732.bin.gz` (binary `@BIN@`)
+  - `tests/models/g170-b6c96-s175395328-d26788732.txt.gz` (text — SAME net)
+  - `tests/models/g170e-b10c128-s1141046784-d204142634.bin.gz` (binary, larger)
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `cpp/tests/testcoremlconvert.cpp` | All converter tests + RSS/hash helpers (METAL-guarded body) | Create |
+| `cpp/tests/tests.h` | Declare the new `Tests::runCoremlConvert*` functions | Modify |
+| `cpp/command/runtests.cpp` | `MainCmds::runcoremlconverttests` dispatcher (METAL-guarded body) | Modify |
+| `cpp/main.h` | Declare `runcoremlconverttests` | Modify |
+| `cpp/main.cpp` | Wire the `"runcoremlconverttests"` subcommand string | Modify |
+| `cpp/CMakeLists.txt` | Add `tests/testcoremlconvert.cpp` to the test sources | Modify |
+| `cpp/external/katagocoreml/src/builder/Operations.hpp` | `WeightEntry` → non-owning view; owned-temp store | Modify |
+| `cpp/external/katagocoreml/src/builder/Operations.cpp` | `registerWeight` (view) + `registerOwnedWeight` (move) | Modify |
+| `cpp/external/katagocoreml/src/builder/MILBuilder.cpp` | matmul-transpose site uses owned path | Modify |
+| `cpp/external/katagocoreml/src/serializer/WeightSerializer.cpp` | read view (`data`/`count`) | Modify |
+| `cpp/external/katagocoreml/src/Converter.cpp` | drop `weights_copy`; scope parser | Modify |
+| `cpp/external/katagocoreml/src/parser/KataGoParser.hpp` | streaming reader members | Modify |
+| `cpp/external/katagocoreml/src/parser/KataGoParser.cpp` | streaming gzip parse (A2) | Modify |
+| `cpp/neuralnet/desc.h` | `ModelDesc::releaseWeights()` declaration (A3) | Modify |
+| `cpp/neuralnet/desc.cpp` | `releaseWeights()` walk (A3) | Modify |
+| `cpp/neuralnet/metalbackend.cpp` | free W1 in ANE convert path (A3) | Modify |
+| `ios/KataGo iOS/KataGo iOS/KataGo iOS.entitlements` | increased-memory-limit entitlement (A4) | Modify |
+
+---
+
+## Task 1: Converter test harness scaffold + smoke test
+
+Establishes the METAL-only `./katago runcoremlconverttests` subcommand and a single smoke test that converts the committed net. This is the foundation every later task builds on.
+
+**Files:**
+- Create: `cpp/tests/testcoremlconvert.cpp`
+- Modify: `cpp/tests/tests.h`, `cpp/command/runtests.cpp`, `cpp/main.h`, `cpp/main.cpp`, `cpp/CMakeLists.txt`
+
+- [ ] **Step 1: Read `ConversionOptions` defaults**
+
+Run: `sed -n '1,120p' "cpp/external/katagocoreml/include/katagocoreml/Options.hpp"`
+Confirm the field names used below (`board_x_size`, `board_y_size`, `compute_precision`, `optimize_identity_mask`, `min_batch_size`, `max_batch_size`) and their defaults. If `min_batch_size` defaults to 0, the test must set it to 1 (the converter throws on `min_batch_size < 1`). Adjust the helper in Step 2 accordingly.
+
+- [ ] **Step 2: Create the test file with the smoke test**
+
+Create `cpp/tests/testcoremlconvert.cpp`:
+
+```cpp
+#include "../tests/tests.h"
+
+#ifdef USE_METAL_BACKEND
+
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <sys/resource.h>
+#include <zlib.h>
+
+#include "../core/sha2.h"
+#include "katagocoreml/KataGoConverter.hpp"
+
+using namespace std;
+
+namespace {
+
+// Process-lifetime peak resident set size in bytes (macOS ru_maxrss is bytes).
+static size_t peakRssBytes() {
+  struct rusage usage;
+  if(getrusage(RUSAGE_SELF, &usage) != 0)
+    return 0;
+  return (size_t)usage.ru_maxrss;
+}
+
+// SHA-256 hex digest of an entire file's bytes.
+static string sha256OfFile(const string& path) {
+  ifstream in(path, ios::binary);
+  if(!in)
+    throw runtime_error("sha256OfFile: cannot open " + path);
+  vector<uint8_t> bytes((istreambuf_iterator<char>(in)), istreambuf_iterator<char>());
+  char hash[65];
+  SHA2::get256(bytes.data(), bytes.size(), hash);
+  return string(hash);
+}
+
+// Number of decompressed bytes in a .gz file, using O(1) memory.
+static size_t gzDecompressedSize(const string& path) {
+  gzFile gz = gzopen(path.c_str(), "rb");
+  if(!gz)
+    throw runtime_error("gzDecompressedSize: cannot open " + path);
+  vector<uint8_t> chunk(1024 * 1024);
+  size_t total = 0;
+  int n;
+  while((n = gzread(gz, chunk.data(), (unsigned)chunk.size())) > 0)
+    total += (size_t)n;
+  gzclose(gz);
+  return total;
+}
+
+// Convert a model and return the path to the produced weight.bin inside the .mlpackage.
+// outPackageDir is the .mlpackage directory created at /tmp.
+static string convertToTemp(
+  const string& modelPath, const string& tag, int boardX, int boardY,
+  bool fp16, bool optimizeMask, string& outPackageDir
+) {
+  outPackageDir = "/tmp/katago_convtest_" + tag + ".mlpackage";
+  katagocoreml::ConversionOptions opts;
+  opts.board_x_size = boardX;
+  opts.board_y_size = boardY;
+  opts.compute_precision = fp16 ? "FLOAT16" : "FLOAT32";
+  opts.optimize_identity_mask = optimizeMask;
+  opts.min_batch_size = 1;
+  opts.max_batch_size = 8;
+  katagocoreml::KataGoConverter::convert(modelPath, outPackageDir, opts);
+  return outPackageDir + "/Data/com.apple.CoreML/weights/weight.bin";
+}
+
+} // namespace
+
+void Tests::runCoremlConvertSmokeTest() {
+  cout << "Running runCoremlConvertSmokeTest" << endl;
+  const string model = "tests/models/g170-b6c96-s175395328-d26788732.bin.gz";
+  string pkg;
+  string weightBin = convertToTemp(model, "smoke", 19, 19, true, false, pkg);
+  ifstream check(weightBin, ios::binary);
+  testAssert(check.good());
+  cout << "  weight.bin sha256 = " << sha256OfFile(weightBin) << endl;
+  cout << "runCoremlConvertSmokeTest passed" << endl;
+}
+
+#endif // USE_METAL_BACKEND
+```
+
+Note: `weight.bin` is written inside the `.mlpackage` by `MPL::ModelPackage` under `Data/com.apple.CoreML/weights/weight.bin`. If Step 2's build/run shows a different layout, fix the `convertToTemp` return path to the actual location (the smoke test's `testAssert(check.good())` will catch it).
+
+- [ ] **Step 3: Declare the test functions in `tests.h`**
+
+In `cpp/tests/tests.h`, add at the end of the `namespace Tests {` block (before its closing `}`):
+
+```cpp
+  //testcoremlconvert.cpp (METAL backend only)
+  void runCoremlConvertSmokeTest();
+  void runCoremlConvertCrossFormatTest();
+  void runCoremlConvertDeterminismTest();
+  void runCoremlConvertGoldenTest();
+  void runCoremlConvertPeakMemoryTest();
+```
+
+- [ ] **Step 4: Declare the subcommand in `main.h`**
+
+In `cpp/main.h`, after line 37 (`int runconfigtests(...)`), add inside `namespace MainCmds {`:
+
+```cpp
+  int runcoremlconverttests(const std::vector<std::string>& args);
+```
+
+- [ ] **Step 5: Wire the subcommand string in `main.cpp`**
+
+In `cpp/main.cpp`, after the `runconfigtests` else-if (around line 129-130), add:
+
+```cpp
+  else if(subcommand == "runcoremlconverttests")
+    return MainCmds::runcoremlconverttests(subArgs);
+```
+
+- [ ] **Step 6: Implement the dispatcher in `runtests.cpp`**
+
+In `cpp/command/runtests.cpp`, add this function (e.g. after `MainCmds::runconfigtests`). The body is METAL-guarded so non-METAL builds still compile:
+
+```cpp
+int MainCmds::runcoremlconverttests(const vector<string>& args) {
+  (void)args;
+#ifdef USE_METAL_BACKEND
+  Tests::runCoremlConvertSmokeTest();
+  Tests::runCoremlConvertCrossFormatTest();
+  Tests::runCoremlConvertDeterminismTest();
+  Tests::runCoremlConvertGoldenTest();
+  Tests::runCoremlConvertPeakMemoryTest();
+  cout << "All CoreML converter tests passed" << endl;
+  return 0;
+#else
+  cout << "runcoremlconverttests is only available in a METAL backend build" << endl;
+  return 0;
+#endif
+}
+```
+
+For Task 1, temporarily comment out the four not-yet-written calls (`runCoremlConvertCrossFormatTest`, `Determinism`, `Golden`, `PeakMemory`) so the build links; uncomment each as its task lands.
+
+- [ ] **Step 7: Add the test source to CMake**
+
+In `cpp/CMakeLists.txt`, find the test sources list (the block adding `tests/*.cpp`, near the other `tests/test*.cpp` entries) and add:
+
+```cmake
+  tests/testcoremlconvert.cpp
+```
+
+- [ ] **Step 8: Build and run the smoke test**
+
+Run:
+```bash
+cd /Users/chinchangyang/Code/KataGo-ios-dev/cpp
+cmake . -G Ninja -DUSE_BACKEND=METAL -DNO_GIT_REVISION=1 && ninja && ./katago runcoremlconverttests
+```
+Expected: `Running runCoremlConvertSmokeTest`, a printed sha256, `runCoremlConvertSmokeTest passed`, then `All CoreML converter tests passed`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add cpp/tests/testcoremlconvert.cpp cpp/tests/tests.h cpp/command/runtests.cpp cpp/main.h cpp/main.cpp cpp/CMakeLists.txt
+git commit -m "test: scaffold katagocoreml converter test subcommand + smoke test"
+```
+
+---
+
+## Task 2: Cross-format equivalence test (the A2 safety net)
+
+Converts the same net from `.bin.gz` (binary path) and `.txt.gz` (text path) and asserts identical `weight.bin`. This is the strongest guard for the A2 parser rewrite and needs no stored golden. Passes on current code (both paths already agree).
+
+**Files:** Modify `cpp/tests/testcoremlconvert.cpp`
+
+- [ ] **Step 1: Write the test**
+
+Add to `cpp/tests/testcoremlconvert.cpp` (inside the `#ifdef USE_METAL_BACKEND` region, after the smoke test):
+
+```cpp
+void Tests::runCoremlConvertCrossFormatTest() {
+  cout << "Running runCoremlConvertCrossFormatTest" << endl;
+  const string binModel = "tests/models/g170-b6c96-s175395328-d26788732.bin.gz";
+  const string txtModel = "tests/models/g170-b6c96-s175395328-d26788732.txt.gz";
+  // Full matrix: precision x board size x optimize_identity_mask. For identical
+  // options, the binary-stream parser and the text parser must agree exactly.
+  for(bool fp16 : {true, false}) {
+    for(auto bs : { std::pair<int,int>{19, 19}, std::pair<int,int>{9, 9} }) {
+      for(bool mask : {false, true}) {
+        string tag = string(fp16 ? "fp16" : "fp32") + "_" + to_string(bs.first)
+                   + "_" + (mask ? "mask" : "nomask");
+        string binPkg, txtPkg;
+        string binWeights = convertToTemp(binModel, "xfmt_bin_" + tag, bs.first, bs.second, fp16, mask, binPkg);
+        string txtWeights = convertToTemp(txtModel, "xfmt_txt_" + tag, bs.first, bs.second, fp16, mask, txtPkg);
+        string binHash = sha256OfFile(binWeights);
+        string txtHash = sha256OfFile(txtWeights);
+        cout << "  " << tag << ": bin=" << binHash << " txt=" << txtHash << endl;
+        testAssert(binHash == txtHash);
+      }
+    }
+  }
+  cout << "runCoremlConvertCrossFormatTest passed" << endl;
+}
+```
+
+This runs 8 combinations (2 precisions × 2 board sizes × 2 mask settings), exercising both parser paths, both precisions, the board-size/mask-constant code, and the `optimize_identity_mask` branch — the spec's full equivalence matrix, with binary-vs-text as the assertion.
+
+- [ ] **Step 2: Enable the call and run**
+
+Uncomment `Tests::runCoremlConvertCrossFormatTest();` in `runtests.cpp`.
+Run: `cd /Users/chinchangyang/Code/KataGo-ios-dev/cpp && ninja && ./katago runcoremlconverttests`
+Expected: `runCoremlConvertCrossFormatTest passed` (binary and text paths produce identical weight blobs at both precisions).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cpp/tests/testcoremlconvert.cpp cpp/command/runtests.cpp
+git commit -m "test: cross-format (bin vs txt) weight-blob equivalence for converter"
+```
+
+---
+
+## Task 3: Determinism test
+
+Converts the same input twice and asserts byte-identical `weight.bin`. Cheap insurance that conversion has no nondeterminism the refactor could perturb. Passes on current code.
+
+**Files:** Modify `cpp/tests/testcoremlconvert.cpp`
+
+- [ ] **Step 1: Write the test**
+
+Add inside the `#ifdef` region:
+
+```cpp
+void Tests::runCoremlConvertDeterminismTest() {
+  cout << "Running runCoremlConvertDeterminismTest" << endl;
+  const string model = "tests/models/g170e-b10c128-s1141046784-d204142634.bin.gz";
+  string pkgA, pkgB;
+  string a = convertToTemp(model, "det_a", 19, 19, true, false, pkgA);
+  string b = convertToTemp(model, "det_b", 19, 19, true, false, pkgB);
+  testAssert(sha256OfFile(a) == sha256OfFile(b));
+  cout << "runCoremlConvertDeterminismTest passed" << endl;
+}
+```
+
+- [ ] **Step 2: Enable the call and run**
+
+Uncomment `Tests::runCoremlConvertDeterminismTest();` in `runtests.cpp`.
+Run: `cd /Users/chinchangyang/Code/KataGo-ios-dev/cpp && ninja && ./katago runcoremlconverttests`
+Expected: `runCoremlConvertDeterminismTest passed`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cpp/tests/testcoremlconvert.cpp cpp/command/runtests.cpp
+git commit -m "test: converter output determinism"
+```
+
+---
+
+## Task 4: Characterization golden test
+
+Pins the exact `weight.bin` + `model.mlmodel` SHA-256 for one config, generated from the **current** converter. Catches any drift the self-comparing tests would miss (e.g. if both parser paths changed identically). Generate the golden first, then it must stay green through A1/A2.
+
+**Files:** Modify `cpp/tests/testcoremlconvert.cpp`
+
+- [ ] **Step 1: Write the test with placeholder golden constants**
+
+Add inside the `#ifdef` region:
+
+```cpp
+void Tests::runCoremlConvertGoldenTest() {
+  cout << "Running runCoremlConvertGoldenTest" << endl;
+  // Golden hashes captured from the pre-refactor converter for
+  // g170-b6c96, FP16, 19x19, optimize_identity_mask=false.
+  // DO NOT change katagocoreml VERSION (embedded in model.mlmodel) or these drift.
+  const string GOLDEN_WEIGHT_SHA = "<FILL_IN_STEP_2>";
+  const string GOLDEN_MODEL_SHA  = "<FILL_IN_STEP_2>";
+
+  const string model = "tests/models/g170-b6c96-s175395328-d26788732.bin.gz";
+  string pkg;
+  string weightBin = convertToTemp(model, "golden", 19, 19, true, false, pkg);
+  string modelSpec = pkg + "/Data/com.apple.CoreML/model.mlmodel";
+
+  string weightSha = sha256OfFile(weightBin);
+  string modelSha = sha256OfFile(modelSpec);
+  cout << "  weight.bin sha256 = " << weightSha << endl;
+  cout << "  model.mlmodel sha256 = " << modelSha << endl;
+
+  testAssert(weightSha == GOLDEN_WEIGHT_SHA);
+  testAssert(modelSha == GOLDEN_MODEL_SHA);
+  cout << "runCoremlConvertGoldenTest passed" << endl;
+}
+```
+
+Note: confirm the `model.mlmodel` relative path inside the `.mlpackage` (the `model.mlmodel` filename is set in `CoreMLSerializer::createPackage`). Fix `modelSpec` if the printed path differs.
+
+- [ ] **Step 2: Capture the golden values**
+
+Uncomment `Tests::runCoremlConvertGoldenTest();` in `runtests.cpp`.
+Run: `cd /Users/chinchangyang/Code/KataGo-ios-dev/cpp && ninja && ./katago runcoremlconverttests`
+The two `testAssert` lines will fail; copy the printed `weight.bin sha256` and `model.mlmodel sha256` into `GOLDEN_WEIGHT_SHA` and `GOLDEN_MODEL_SHA`.
+
+- [ ] **Step 3: Re-run to confirm green**
+
+Run: `ninja && ./katago runcoremlconverttests`
+Expected: `runCoremlConvertGoldenTest passed`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cpp/tests/testcoremlconvert.cpp cpp/command/runtests.cpp
+git commit -m "test: pin converter golden weight.bin + model.mlmodel hashes"
+```
+
+---
+
+## Task 5: Peak-memory measurement + ratio assertion
+
+Measures conversion peak RSS. The strict ratio gate (`peak < decompressed × R`) is enforced only when `KATAGO_COREML_PEAK_MODEL` points at a large net (run locally against b40c768); otherwise it logs and applies a loose sanity bound on the small committed net.
+
+**Files:** Modify `cpp/tests/testcoremlconvert.cpp`
+
+- [ ] **Step 1: Write the test**
+
+Add inside the `#ifdef` region:
+
+```cpp
+void Tests::runCoremlConvertPeakMemoryTest() {
+  cout << "Running runCoremlConvertPeakMemoryTest" << endl;
+  const char* envModel = getenv("KATAGO_COREML_PEAK_MODEL");
+  bool strict = (envModel != nullptr);
+  string model = strict ? string(envModel)
+                        : string("tests/models/g170e-b10c128-s1141046784-d204142634.bin.gz");
+
+  size_t decompressed = gzDecompressedSize(model);
+  string pkg;
+  string weightBin = convertToTemp(model, "peak", 19, 19, true, false, pkg);
+  (void)weightBin;
+  size_t peak = peakRssBytes();
+
+  double ratio = (double)peak / (double)decompressed;
+  cout << "  model = " << model << endl;
+  cout << "  decompressed = " << (decompressed / (1024 * 1024)) << " MB" << endl;
+  cout << "  peak RSS     = " << (peak / (1024 * 1024)) << " MB" << endl;
+  cout << "  ratio        = " << ratio << "x" << endl;
+
+  // R: target peak/decompressed multiplier. Pre-refactor holds ~3x FP32 copies
+  // + the decompressed buffer, so the real (large-net) ratio starts well above this.
+  const double R = 1.5;
+  if(strict) {
+    testAssert(ratio < R);
+  } else {
+    // Small committed net: baseline RSS dominates; just guard against a runaway.
+    testAssert(peak < (size_t)2 * 1024 * 1024 * 1024);
+  }
+  cout << "runCoremlConvertPeakMemoryTest passed" << endl;
+}
+```
+
+- [ ] **Step 2: Run the loose (committed-net) path**
+
+Uncomment `Tests::runCoremlConvertPeakMemoryTest();` in `runtests.cpp`.
+Run: `cd /Users/chinchangyang/Code/KataGo-ios-dev/cpp && ninja && ./katago runcoremlconverttests`
+Expected: prints the ratio and `runCoremlConvertPeakMemoryTest passed` (loose bound). Record the printed ratio as the pre-refactor baseline.
+
+- [ ] **Step 3: Observe the RED on the real net (local, large-net gate)**
+
+Obtain the b40c768 `.bin.gz` locally (the Official network download, or any large net) and run:
+```bash
+KATAGO_COREML_PEAK_MODEL=/path/to/kata1-zhizi-b40c768nbt-fdx6d.bin.gz ./katago runcoremlconverttests
+```
+Expected: `runCoremlConvertPeakMemoryTest` **FAILS** the `ratio < 1.5` assertion (peak ≈ 3–4× decompressed) — this is the red state A1+A2 will turn green. Record the peak MB and ratio.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cpp/tests/testcoremlconvert.cpp cpp/command/runtests.cpp
+git commit -m "test: conversion peak-RSS ratio gate (strict on KATAGO_COREML_PEAK_MODEL)"
+```
+
+---
+
+## Task 6: A1 — `WeightEntry` becomes a non-owning view
+
+Remove copies #2 and #3 by making `WeightEntry` reference the weights in the live `model` instead of copying them. The one `registerWeight` site that passes a temporary (the matmul transpose) gets an owned-buffer path.
+
+**Files:** Modify `cpp/external/katagocoreml/src/builder/Operations.hpp`, `Operations.cpp`, `MILBuilder.cpp`, `serializer/WeightSerializer.cpp`
+
+- [ ] **Step 1: Change `WeightEntry` + `KataGoOps` to views in `Operations.hpp`**
+
+Replace the `WeightEntry` struct (lines 13-19) with:
+
+```cpp
+/// Weight entry for blob file storage. `data`/`count` are a NON-OWNING view into
+/// the live KataGoModelDesc (or into KataGoOps::m_owned for derived tensors).
+struct WeightEntry {
+    std::string name;
+    const float* data = nullptr;
+    size_t count = 0;
+    std::vector<int64_t> shape;
+    uint64_t blob_offset = 0;  // Set during serialization
+};
+```
+
+Add `#include <deque>` near the top. In `class KataGoOps`, add a second registration method and an owned-buffer store. Replace the `registerWeight` declaration (lines 54-57) with:
+
+```cpp
+    /// Register a weight that lives in the model (stored as a non-owning view).
+    std::string registerWeight(const std::string& name,
+                               const std::vector<float>& data,
+                               const std::vector<int64_t>& shape);
+
+    /// Register a derived/temporary weight; KataGoOps takes ownership so the
+    /// view stays valid through serialization.
+    std::string registerOwnedWeight(const std::string& name,
+                                    std::vector<float>&& data,
+                                    const std::vector<int64_t>& shape);
+```
+
+And in the `private:` section add (a `std::deque` keeps element addresses stable across appends, unlike `std::vector`):
+
+```cpp
+    std::deque<std::vector<float>> m_owned;
+```
+
+- [ ] **Step 2: Implement both methods in `Operations.cpp`**
+
+Replace `registerWeight` (lines 15-25) with:
+
+```cpp
+std::string KataGoOps::registerWeight(const std::string& name,
+                                       const std::vector<float>& data,
+                                       const std::vector<int64_t>& shape) {
+    WeightEntry entry;
+    entry.name = name;
+    entry.data = data.data();
+    entry.count = data.size();
+    entry.shape = shape;
+    entry.blob_offset = 0;
+    m_weights.push_back(std::move(entry));
+    return name;
+}
+
+std::string KataGoOps::registerOwnedWeight(const std::string& name,
+                                            std::vector<float>&& data,
+                                            const std::vector<int64_t>& shape) {
+    m_owned.push_back(std::move(data));
+    const std::vector<float>& stored = m_owned.back();
+    WeightEntry entry;
+    entry.name = name;
+    entry.data = stored.data();
+    entry.count = stored.size();
+    entry.shape = shape;
+    entry.blob_offset = 0;
+    m_weights.push_back(std::move(entry));
+    return name;
+}
+```
+
+- [ ] **Step 3: Route the matmul-transpose temporary through the owned path in `MILBuilder.cpp`**
+
+The transpose site builds a local `transposed_weights` (around lines 950-961) and calls `addConstOp(block, weight_name, transposed_weights, transposed_shape);`. `addConstOp` (line 211) forwards to `m_ops.registerWeight`, which would now store a dangling view. Replace that one `addConstOp(...)` call (line 961) with a direct owned registration plus the const-op emission it needs. First inspect `addConstOp` to see what MIL op it appends besides `registerWeight`:
+
+Run: `sed -n '205,250p' cpp/external/katagocoreml/src/builder/MILBuilder.cpp`
+
+Then refactor `addConstOp` to split weight registration from op emission. Change `addConstOp` (line 211-217 region) so registration is a parameter:
+
+```cpp
+// New private helper: emit the const op given an already-registered weight name.
+void MILBuilder::emitConstOp(CoreML::Specification::MILSpec::Block* block,
+                             const std::string& name,
+                             const std::vector<int64_t>& shape) {
+    // <-- move here the body of the existing addConstOp that builds the const
+    //     operation/attributes using `name` and `shape`, i.e. everything AFTER
+    //     the m_ops.registerWeight(...) line.
+}
+
+void MILBuilder::addConstOp(CoreML::Specification::MILSpec::Block* block,
+                            const std::string& name,
+                            const std::vector<float>& data,
+                            const std::vector<int64_t>& shape) {
+    m_ops.registerWeight(name, data, shape);
+    emitConstOp(block, name, shape);
+}
+
+void MILBuilder::addOwnedConstOp(CoreML::Specification::MILSpec::Block* block,
+                                 const std::string& name,
+                                 std::vector<float>&& data,
+                                 const std::vector<int64_t>& shape) {
+    m_ops.registerOwnedWeight(name, std::move(data), shape);
+    emitConstOp(block, name, shape);
+}
+```
+
+Declare `emitConstOp` and `addOwnedConstOp` in `MILBuilder.hpp` next to `addConstOp`. Then at line 961 replace:
+
+```cpp
+    addConstOp(block, weight_name, transposed_weights, transposed_shape);
+```
+with:
+```cpp
+    addOwnedConstOp(block, weight_name, std::move(transposed_weights), transposed_shape);
+```
+
+- [ ] **Step 4: Read the view in `WeightSerializer.cpp`**
+
+Replace the loop body (lines 17-33) so it uses `entry.data` (pointer) and `entry.count`:
+
+```cpp
+    for(auto& entry : weights) {
+        if(use_fp16) {
+            std::vector<MILBlob::Fp16> fp16_data(entry.count);
+            for(size_t i = 0; i < entry.count; ++i) {
+                fp16_data[i] = MILBlob::Fp16::FromFloat(entry.data[i]);
+            }
+            MILBlob::Util::Span<const MILBlob::Fp16> span(fp16_data.data(), fp16_data.size());
+            entry.blob_offset = writer.WriteData(span);
+            total_bytes += entry.count * sizeof(MILBlob::Fp16);
+        } else {
+            MILBlob::Util::Span<const float> span(entry.data, entry.count);
+            entry.blob_offset = writer.WriteData(span);
+            total_bytes += entry.count * sizeof(float);
+        }
+    }
+```
+
+- [ ] **Step 5: Build and run all converter tests (goldens must stay green)**
+
+Run: `cd /Users/chinchangyang/Code/KataGo-ios-dev/cpp && ninja && ./katago runcoremlconverttests`
+Expected: smoke, cross-format, determinism, **golden** all pass (byte-identical output preserved), and the peak ratio (re-run with `KATAGO_COREML_PEAK_MODEL`) drops — copies #2 and #3 of the weight DATA are gone (the `weights_copy` vector now copies only view structs).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cpp/external/katagocoreml/src/builder/Operations.hpp cpp/external/katagocoreml/src/builder/Operations.cpp cpp/external/katagocoreml/src/builder/MILBuilder.hpp cpp/external/katagocoreml/src/builder/MILBuilder.cpp cpp/external/katagocoreml/src/serializer/WeightSerializer.cpp
+git commit -m "perf(katagocoreml): weights as non-owning views to drop 2 of 3 FP32 copies"
+```
+
+---
+
+## Task 7: A1 cleanup — drop `weights_copy` and scope the parser
+
+`weights_copy` is now a shallow copy of view structs; remove it for clarity and pass the builder's weights directly. Also scope the parser so the (still-full, until A2) decompressed buffer is destroyed before serialize.
+
+**Files:** Modify `cpp/external/katagocoreml/src/Converter.cpp`, `MILBuilder.hpp`
+
+- [ ] **Step 1: Expose a mutable weights accessor on `MILBuilder`**
+
+`WeightSerializer::serialize` and `CoreMLSerializer::serialize` take `std::vector<WeightEntry>&` (they set `blob_offset`). In `MILBuilder.hpp`, ensure there is a non-const accessor:
+
+```cpp
+    std::vector<WeightEntry>& getWeightsMutable() { return m_ops.getWeightsMutable(); }
+```
+and in `Operations.hpp` add to `KataGoOps`:
+```cpp
+    std::vector<WeightEntry>& getWeightsMutable() { return m_weights; }
+```
+
+- [ ] **Step 2: Rewrite the parse/serialize section of `Converter.cpp`**
+
+Replace lines 32-34 (parser) so the parser is scoped, and lines 53-57 (build + `weights_copy`):
+
+```cpp
+    // Parse KataGo model (parser + its decompressed buffer freed at end of scope)
+    KataGoModelDesc model;
+    {
+        KataGoParser parser(input_path);
+        model = parser.parse();
+    }
+```
+and:
+```cpp
+    auto program = builder.build();
+    // Serialize directly from the builder's weight views (no copy).
+    std::vector<WeightEntry>& weights = builder.getWeightsMutable();
+```
+Then update the final serialize call (line 85) to pass `weights` instead of `weights_copy`:
+```cpp
+    serializer.serialize(program.get(), weights, output_path, final_options);
+```
+Confirm `KataGoModelDesc` is movable (it has `std::vector`/`std::optional` members and no deleted move) so `model = parser.parse();` compiles; if not, keep `KataGoModelDesc model = parser.parse();` but wrap only the `KataGoParser` lifetime — i.e. make `parse()` the last use of the parser and let the `parser` local fall out of scope naturally before `builder.build()` (move the `MILBuilder` construction after a `}` that ends the parser's scope).
+
+- [ ] **Step 3: Build and run all converter tests**
+
+Run: `cd /Users/chinchangyang/Code/KataGo-ios-dev/cpp && ninja && ./katago runcoremlconverttests`
+Expected: all converter tests pass (goldens unchanged).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cpp/external/katagocoreml/src/Converter.cpp cpp/external/katagocoreml/src/builder/MILBuilder.hpp cpp/external/katagocoreml/src/builder/Operations.hpp
+git commit -m "perf(katagocoreml): drop weights_copy, scope parser buffer before serialize"
+```
+
+---
+
+## Task 8: A2 — streaming gzip parse (no full decompressed buffer)
+
+Replace the whole-file `m_buffer` with an on-demand gzip stream so the ~decompressed-file-sized buffer is never resident. Highest correctness risk; the cross-format + golden tests are the gate.
+
+**Files:** Modify `cpp/external/katagocoreml/src/parser/KataGoParser.hpp`, `KataGoParser.cpp`
+
+- [ ] **Step 1: Replace the parser's buffer members in `KataGoParser.hpp`**
+
+Replace lines 33-36 (`m_model_path`, `m_buffer`, `m_pos`, `m_binary_floats`) with a streaming reader holding the gz handle and a small refill buffer:
+
+```cpp
+    std::string m_model_path;
+    gzFile m_gz = nullptr;
+    std::vector<uint8_t> m_refill;   // bounded refill buffer (~1 MB)
+    size_t m_refillPos = 0;          // read cursor within m_refill
+    size_t m_refillLen = 0;          // valid bytes in m_refill
+    bool m_binary_floats = true;
+    bool m_formatDetected = false;
+```
+Add `#include <zlib.h>` to the header (or forward via `typedef` if you prefer keeping zlib out of the header — simplest is to include it). Add private stream primitives:
+
+```cpp
+    // Streaming primitives (read from m_gz via m_refill)
+    bool refill();                   // returns false at EOF
+    int  peekByte();                 // -1 at EOF
+    int  getByte();                  // -1 at EOF
+    void readExact(uint8_t* dst, size_t n, const std::string& name);
+```
+Remove `loadFile()`. Keep `readUntilWhitespace`, `skipWhitespace`, `readString`, `readInt`, `readFloat`, `readBool`, `readFloats` (their implementations change).
+
+- [ ] **Step 2: Implement the streaming primitives in `KataGoParser.cpp`**
+
+Replace `loadFile()` and the low-level readers (lines 36-184) with a streaming implementation. Open the gz in the constructor body or at start of `parse()`:
+
+```cpp
+bool KataGoParser::refill() {
+    if(m_gz == nullptr) return false;
+    int n = gzread(m_gz, m_refill.data(), (unsigned)m_refill.size());
+    if(n < 0) {
+        int errnum;
+        const char* errmsg = gzerror(m_gz, &errnum);
+        throw std::runtime_error("Error reading gzip stream: " + std::string(errmsg));
+    }
+    m_refillPos = 0;
+    m_refillLen = (size_t)n;
+    return n > 0;
+}
+
+int KataGoParser::peekByte() {
+    if(m_refillPos >= m_refillLen) {
+        if(!refill()) return -1;
+    }
+    return (int)m_refill[m_refillPos];
+}
+
+int KataGoParser::getByte() {
+    int c = peekByte();
+    if(c >= 0) m_refillPos++;
+    return c;
+}
+
+void KataGoParser::readExact(uint8_t* dst, size_t n, const std::string& name) {
+    size_t got = 0;
+    while(got < n) {
+        if(m_refillPos >= m_refillLen) {
+            if(!refill())
+                throw std::runtime_error(name + ": unexpected EOF in binary block");
+        }
+        size_t avail = m_refillLen - m_refillPos;
+        size_t take = std::min(avail, n - got);
+        std::memcpy(dst + got, m_refill.data() + m_refillPos, take);
+        m_refillPos += take;
+        got += take;
+    }
+}
+```
+
+Rewrite the text readers against the stream:
+
+```cpp
+void KataGoParser::skipWhitespace() {
+    int c;
+    while((c = peekByte()) >= 0) {
+        if(c != ' ' && c != '\t' && c != '\n' && c != '\r') break;
+        m_refillPos++;
+    }
+}
+
+void KataGoParser::readUntilWhitespace(std::string& out) {
+    out.clear();
+    int c;
+    while((c = peekByte()) >= 0) {
+        if(c == ' ' || c == '\t' || c == '\n' || c == '\r') break;
+        out += (char)c;
+        m_refillPos++;
+    }
+}
+```
+`readString`/`readInt`/`readFloat`/`readBool` keep their bodies (they call `readString` then `std::stoi`/`std::stof`).
+
+- [ ] **Step 3: Open the stream and detect format in `parse()`**
+
+Replace `parse()` (lines 88-99). KataGo `.bin.gz` model files put their float blocks behind a `@BIN@` marker; the old code scanned the whole file. Stream version: detect on the first `readFloats` binary block instead. Also support a plain (non-`.gz`) path by wrapping with `gzopen` (zlib transparently reads uncompressed files too):
+
+```cpp
+KataGoModelDesc KataGoParser::parse() {
+    m_gz = gzopen(m_model_path.c_str(), "rb");
+    if(m_gz == nullptr)
+        throw std::runtime_error("Cannot open file: " + m_model_path);
+    m_refill.resize(1024 * 1024);
+    m_refillPos = 0;
+    m_refillLen = 0;
+    m_formatDetected = false;   // decided at first readFloats
+    m_binary_floats = true;
+    KataGoModelDesc model;
+    try {
+        model = parseModel();
+    } catch(...) {
+        gzclose(m_gz);
+        m_gz = nullptr;
+        throw;
+    }
+    gzclose(m_gz);
+    m_gz = nullptr;
+    return model;
+}
+```
+Note: `gzopen` reads uncompressed files transparently, so the previous separate `.gz`-vs-plain branch is no longer needed.
+
+- [ ] **Step 4: Stream `readFloats` with inline `@BIN@` detection**
+
+Replace `readFloats` (lines 148-184). The format is: optional whitespace, then either ASCII float tokens or a `@BIN@` marker immediately preceding `count*4` little-endian float32 bytes. Detect format once, at the first call, by peeking for `@`:
+
+```cpp
+std::vector<float> KataGoParser::readFloats(size_t count, const std::string& name) {
+    std::vector<float> floats(count);
+    skipWhitespace();
+
+    if(!m_formatDetected) {
+        m_binary_floats = (peekByte() == '@');
+        m_formatDetected = true;
+    }
+
+    if(!m_binary_floats) {
+        for(size_t i = 0; i < count; i++)
+            floats[i] = readFloat();
+        return floats;
+    }
+
+    // Binary: consume the "@BIN@" marker, then read count*4 raw bytes.
+    char marker[5];
+    readExact(reinterpret_cast<uint8_t*>(marker), 5, name);
+    if(std::memcmp(marker, "@BIN@", 5) != 0)
+        throw std::runtime_error(name + ": expected @BIN@ marker for binary float block");
+
+    readExact(reinterpret_cast<uint8_t*>(floats.data()), count * 4, name);
+    return floats;
+}
+```
+Notes: the old code scanned forward past arbitrary bytes to the `@`; here `skipWhitespace` + the per-block `@BIN@` consume is equivalent because in KataGo binary files each float block is preceded only by whitespace then the marker. Keep `#include <cstring>` and `#include <algorithm>`.
+
+- [ ] **Step 5: Build and run all converter tests — equivalence MUST hold**
+
+Run: `cd /Users/chinchangyang/Code/KataGo-ios-dev/cpp && ninja && ./katago runcoremlconverttests`
+Expected: smoke, **cross-format** (binary stream vs text), **determinism**, **golden** all pass — byte-identical output. If the golden fails, the streaming parser diverged; debug against the cross-format test (it isolates binary-vs-text).
+
+- [ ] **Step 6: Confirm the peak drop on the real net**
+
+Run: `KATAGO_COREML_PEAK_MODEL=/path/to/b40c768.bin.gz ./katago runcoremlconverttests`
+Expected: the peak ratio now satisfies `ratio < 1.5` (the decompressed buffer is gone and only one FP32 copy remains) — the test that was RED in Task 5 Step 3 is now GREEN. Record the new peak MB.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cpp/external/katagocoreml/src/parser/KataGoParser.hpp cpp/external/katagocoreml/src/parser/KataGoParser.cpp
+git commit -m "perf(katagocoreml): stream gzip parse, drop full decompressed buffer (A2)"
+```
+
+---
+
+## Task 9: A3 — free the engine's ANE-dead `modelDesc` weights
+
+The engine loads the full `ModelDesc` (W1) before conversion; in ANE mode its weight arrays are never read again (only MPSGraph/GPU uses them). Free them right after reading the scalar dims the bridge needs, removing W1 from both the convert and compile phases (and ~1.6 GB of steady-state RSS on iOS).
+
+**Files:** Modify `cpp/neuralnet/desc.h`, `cpp/neuralnet/desc.cpp`, `cpp/neuralnet/metalbackend.cpp`
+
+- [ ] **Step 1: Declare `releaseWeights()` on `ModelDesc`**
+
+In `cpp/neuralnet/desc.h`, in `struct ModelDesc` (after `getSupportedRules`, around line 389), add:
+
+```cpp
+  // Frees all weight arrays (conv/matmul/bias/batchnorm), keeping scalar shape
+  // metadata intact. Safe to call once the weights are no longer needed (e.g.
+  // CoreML/ANE inference, which reads weights from the compiled .mlmodelc).
+  void releaseWeights();
+```
+
+- [ ] **Step 2: Implement the walk in `desc.cpp`**
+
+At the end of `cpp/neuralnet/desc.cpp` (before the final namespace/`#endif` if any; this file is plain global-namespace functions), add file-local helpers and the method. Mirror the existing `iterConvLayers` block-dispatch (`desc.cpp:742-762`, `1143-1160`) for the type-erased `blocks`:
+
+```cpp
+static void releaseVec(std::vector<float>& v) { std::vector<float>().swap(v); }
+
+static void releaseConv(ConvLayerDesc& c) { releaseVec(c.weights); }
+
+static void releaseBN(BatchNormLayerDesc& b) {
+  releaseVec(b.mean); releaseVec(b.variance); releaseVec(b.scale);
+  releaseVec(b.bias); releaseVec(b.mergedScale); releaseVec(b.mergedBias);
+}
+
+static void releaseMatMul(MatMulLayerDesc& m) { releaseVec(m.weights); }
+static void releaseMatBias(MatBiasLayerDesc& m) { releaseVec(m.weights); }
+
+static void releaseResidual(ResidualBlockDesc& b) {
+  releaseBN(b.preBN); releaseConv(b.regularConv);
+  releaseBN(b.midBN); releaseConv(b.finalConv);
+}
+
+static void releaseGPool(GlobalPoolingResidualBlockDesc& b) {
+  releaseBN(b.preBN); releaseConv(b.regularConv); releaseConv(b.gpoolConv);
+  releaseBN(b.gpoolBN); releaseMatMul(b.gpoolToBiasMul);
+  releaseBN(b.midBN); releaseConv(b.finalConv);
+}
+
+static void releaseBlocks(std::vector<std::pair<int, unique_ptr_void>>& blocks);
+
+static void releaseNested(NestedBottleneckResidualBlockDesc& b) {
+  releaseBN(b.preBN); releaseConv(b.preConv);
+  releaseBlocks(b.blocks);
+  releaseBN(b.postBN); releaseConv(b.postConv);
+}
+
+static void releaseBlocks(std::vector<std::pair<int, unique_ptr_void>>& blocks) {
+  for(size_t i = 0; i < blocks.size(); i++) {
+    if(blocks[i].first == ORDINARY_BLOCK_KIND)
+      releaseResidual(*(ResidualBlockDesc*)blocks[i].second.get());
+    else if(blocks[i].first == GLOBAL_POOLING_BLOCK_KIND)
+      releaseGPool(*(GlobalPoolingResidualBlockDesc*)blocks[i].second.get());
+    else if(blocks[i].first == NESTED_BOTTLENECK_BLOCK_KIND)
+      releaseNested(*(NestedBottleneckResidualBlockDesc*)blocks[i].second.get());
+    else
+      testAssert(false);
+  }
+}
+
+static void releaseSGFEncoder(SGFMetadataEncoderDesc& e) {
+  releaseMatMul(e.mul1); releaseMatBias(e.bias1);
+  releaseMatMul(e.mul2); releaseMatBias(e.bias2);
+  releaseMatMul(e.mul3);
+}
+
+void ModelDesc::releaseWeights() {
+  // Trunk
+  releaseConv(trunk.initialConv);
+  releaseMatMul(trunk.initialMatMul);
+  if(trunk.metaEncoderVersion > 0)
+    releaseSGFEncoder(trunk.sgfMetadataEncoder);
+  releaseBlocks(trunk.blocks);
+  releaseBN(trunk.trunkTipBN);
+  // Policy head
+  releaseConv(policyHead.p1Conv); releaseConv(policyHead.g1Conv);
+  releaseBN(policyHead.g1BN); releaseMatMul(policyHead.gpoolToBiasMul);
+  releaseBN(policyHead.p1BN); releaseConv(policyHead.p2Conv);
+  releaseMatMul(policyHead.gpoolToPassMul); releaseMatBias(policyHead.gpoolToPassBias);
+  releaseMatMul(policyHead.gpoolToPassMul2);
+  // Value head
+  releaseConv(valueHead.v1Conv); releaseBN(valueHead.v1BN);
+  releaseMatMul(valueHead.v2Mul); releaseMatBias(valueHead.v2Bias);
+  releaseMatMul(valueHead.v3Mul); releaseMatBias(valueHead.v3Bias);
+  releaseMatMul(valueHead.sv3Mul); releaseMatBias(valueHead.sv3Bias);
+  releaseConv(valueHead.vOwnershipConv);
+}
+```
+Note: confirm `testAssert` is available in `desc.cpp` (it is used by `iterConvLayers` in the same file). If `desc.cpp` has a trailing `#endif`, insert the code before it.
+
+- [ ] **Step 3: Free W1 in the ANE convert path of `metalbackend.cpp`**
+
+In `convertAndCreateCoreMLOnlyHandle` (`metalbackend.cpp:451`), the function is reached only for ANE (its caller returns `none()` unless `gpuIdx == METAL_MUX_ANE`). The bridge call reads scalar dims from `modelDesc` at lines 472-478. Capture those scalars into locals first, then release W1's weights before the (file-re-reading) conversion. Right before the `invokeCoreMLBridge(...)` call (line 468), insert:
+
+```cpp
+  // ANE path only: the compiled .mlmodelc carries the weights; the engine's
+  // ModelDesc weight arrays are never read again. Free them to remove ~1 net's
+  // worth of FP32 weights from the conversion peak and from steady-state RSS.
+  // (modelDesc scalar dims below stay valid; releaseWeights() keeps them.)
+  const_cast<LoadedModel*>(loadedModel)->modelDesc.releaseWeights();
+```
+The scalar fields passed to `invokeCoreMLBridge` (`numInputChannels`, etc., lines 472-478) and to the legacy fallback (lines 502-508) are untouched by `releaseWeights()`. The `ComputeHandle` constructor's later reads of `modelDesc->modelVersion`/`metaEncoderVersion` (lines 585-586) and `InputBuffers`' `m.policyHead.p2Conv.outChannels` (line 648) are also scalar and remain valid.
+
+- [ ] **Step 4: Build all three platforms (A3 touches shared engine code)**
+
+This task changes `desc.h`/`desc.cpp` (shared) and `metalbackend.cpp`. Verify the METAL C++ build first, then the three app platforms.
+```bash
+cd /Users/chinchangyang/Code/KataGo-ios-dev/cpp && ninja && ./katago runcoremlconverttests
+```
+Expected: converter tests still pass (this task does not change conversion output).
+Then the app builds (from `ios/KataGo iOS`):
+```bash
+xcodebuild build -project "KataGo Anytime.xcodeproj" -scheme "KataGo Anytime" -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug
+xcodebuild build -project "KataGo Anytime.xcodeproj" -scheme "KataGo Anytime" -destination 'platform=macOS' -configuration Debug
+```
+Expected: both build succeed. (visionOS sim runtime may be unavailable locally — skip if it fails to install per project memory.)
+
+- [ ] **Step 5: Sanity-check inference still works (ANE weights freed)**
+
+Launch the macOS app (or run on a device) and confirm a model loads and analysis produces moves — i.e. freeing W1 did not break CoreML inference (which reads from the compiled `.mlmodelc`, not `modelDesc`).
+Run: `xcodebuild build ...` already done; then run the app via the `run` skill or Xcode and load a net.
+Expected: analysis runs normally; no crash referencing empty weight arrays.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cpp/neuralnet/desc.h cpp/neuralnet/desc.cpp cpp/neuralnet/metalbackend.cpp
+git commit -m "perf(metal): free ANE-dead ModelDesc weights after dim read (A3)"
+```
+
+---
+
+## Task 10: A4 — increased-memory-limit entitlement
+
+Raise the per-app jetsam ceiling on supported devices.
+
+**Files:** Modify `ios/KataGo iOS/KataGo iOS/KataGo iOS.entitlements`
+
+- [ ] **Step 1: Add the entitlement keys**
+
+In `ios/KataGo iOS/KataGo iOS/KataGo iOS.entitlements`, inside the top-level `<dict>` (after the existing iCloud array, before `</dict>`), add:
+
+```xml
+	<key>com.apple.developer.kernel.increased-memory-limit</key>
+	<true/>
+	<key>com.apple.developer.kernel.extended-virtual-addressing</key>
+	<true/>
+```
+
+- [ ] **Step 2: Build for iOS to confirm signing accepts the entitlement**
+
+Run (from `ios/KataGo iOS`):
+```bash
+xcodebuild build -project "KataGo Anytime.xcodeproj" -scheme "KataGo Anytime" -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug
+```
+Expected: build succeeds. (If a provisioning-profile error appears for the increased-memory-limit capability, enable the capability in the target's Signing & Capabilities, or note it for the device build — the simulator build should not require it.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "ios/KataGo iOS/KataGo iOS/KataGo iOS.entitlements"
+git commit -m "feat(ios): add increased-memory-limit entitlement (A4)"
+```
+
+---
+
+## Task 11: Final verification & device measurement
+
+- [ ] **Step 1: Full converter test suite (Mac)**
+
+Run: `cd /Users/chinchangyang/Code/KataGo-ios-dev/cpp && ninja && ./katago runcoremlconverttests`
+Expected: all converter tests pass. Also run the broader suite to confirm no regression: `./katago runtests`.
+
+- [ ] **Step 2: Strict peak gate on the real net (Mac)**
+
+Run: `KATAGO_COREML_PEAK_MODEL=/path/to/b40c768.bin.gz ./katago runcoremlconverttests`
+Expected: `runCoremlConvertPeakMemoryTest passed` with `ratio < 1.5`. Record before/after peak MB in the commit message.
+
+- [ ] **Step 3: All three app platforms build**
+
+From `ios/KataGo iOS`, build iOS Simulator, macOS, and (if the runtime is installed) visionOS Simulator per `CLAUDE.md`.
+Expected: builds succeed.
+
+- [ ] **Step 4: On-device load test (the real acceptance gate)**
+
+Install on the iPhone 17 and the iPad mini 6. Download/select the Official b40c768 net and confirm it loads and runs analysis without a jetsam kill. Capture the on-device peak (Xcode memory gauge / Instruments).
+- If both devices load successfully: the OOM is fixed; proceed to Step 5.
+- If the 4 GB iPad mini 6 still OOMs: implement **A5** (full layer-streaming convert) per the spec, then re-measure. A5 is out of scope for this plan's tasks and triggers only here.
+
+- [ ] **Step 5: Final commit / branch wrap-up**
+
+Use the finishing-a-development-branch skill to merge/PR. Note in the PR the measured before/after conversion peak and the on-device load results.
+
+---
+
+## Notes on deferred work
+
+- **A5 (full layer-streaming convert)** is intentionally NOT a task here. It is triggered only if Task 11 Step 4 shows the 4 GB device still OOMs after A1–A4. It would restructure the converter to stream weights parse→FP16→blob→free per layer (peak ≈ one layer) and tighten the peak test's `R`.
+- **Modern-architecture CI fixture:** the committed nets don't exercise nested-bottleneck blocks / SGF-metadata / model versions ≥ 15 (what b40c768nbt uses). The developer-run `KATAGO_COREML_PEAK_MODEL` golden/peak run against the real b40c768 is the gate for those paths until a small modern fixture is committed (spec follow-up).

--- a/docs/superpowers/specs/2026-05-30-reduce-conversion-peak-memory-design.md
+++ b/docs/superpowers/specs/2026-05-30-reduce-conversion-peak-memory-design.md
@@ -1,0 +1,215 @@
+# Reduce On-Device CoreML Conversion Peak Memory (b40c768 OOM Fix)
+
+**Date:** 2026-05-30
+**Status:** Design approved, pending implementation plan
+**Topic:** Eliminate the out-of-memory (jetsam) crash when loading the Official b40c768nbt network on iOS
+
+## Problem
+
+After commit `4694079c` updated the Official network to `kata1-zhizi-b40c768nbt-fdx6d`
+(40 blocks / 768 channels, ~824 MB `.bin.gz`), the app crashes on **iPhone 17** and
+**iPad mini 6** immediately after the net downloads and the engine launches. The root
+cause is **memory exhaustion (jetsam), not a stack overflow**: peak ~5 GB during the
+one-time, on-device `bin.gz → CoreML` conversion + model load. It does **not** reproduce
+on macOS or the iOS Simulator (they have enough RAM).
+
+The crash is a *one-time conversion spike* on first load of a given model. Subsequent
+launches hit the CoreML cache (`.mlmodelc/` on disk) and skip the conversion entirely.
+
+## Goal
+
+Make the b40c768 net's first-load conversion fit within a **4 GB device's** jetsam
+budget (~2 GB raw, ~3 GB with the increased-memory-limit entitlement), so b40c768 works
+as the Official network on **all** supported devices — including the 4 GB iPad mini 6.
+
+**Constraints (decided during brainstorming):**
+
+- **Keep on-device conversion.** Continue downloading `.bin.gz` and converting on the
+  device; do not change the distribution model (no hosting of pre-converted artifacts).
+- **Verify via a Mac-side conversion peak test.** Primary verification is an automated,
+  CI-able test measuring the C++ converter pipeline's peak RSS. It does not capture
+  `compileModel`/device jetsam directly; those are validated by on-device runs.
+- Output `.mlpackage` bytes and inference precision (FP16 on ANE) must be unchanged.
+- macOS GPU/MPSGraph path must remain byte-for-byte unaffected.
+
+## Where the ~5 GB comes from
+
+Conversion runs in **two non-overlapping phases**. The C++ converter structures are torn
+down (their `convert_to_temp` call returns) *before* `MLModel.compileModel` runs, so the
+two phases are budgeted separately.
+
+| Phase | Resident today | Approx. peak today | Measured by |
+|---|---|---|---|
+| **Convert** (`katagocoreml_convert_to_temp`, C++) | decompressed buffer (B) + **3×** FP32 weights + per-layer FP16 temp | ~B + 3× weights | **Mac peak test** |
+| **Compile** (`MLModel.compileModel`, after C++ teardown) | engine `modelDesc` weights (W1, FP32) + on-disk package + Apple working set | W1 + Apple internal | On-device only |
+
+**The 3× FP32 duplication in the convert phase** (`cpp/external/katagocoreml/src/Converter.cpp:34,45,56-57`):
+
+1. `model` — the parsed `KataGoModelDesc` (weights stored by value in each layer desc).
+2. `builder`'s `m_ops.m_weights` — `WeightEntry.data` is `std::vector<float>` **by value**,
+   so `KataGoOps::registerWeight` *copies* every tensor (`Operations.hpp:14-19,55-57`).
+3. `weights_copy(weights.begin(), weights.end())` — an explicit full copy of all weights.
+
+Plus the decompressed file buffer (`KataGoParser::m_buffer`) stays alive because the
+`parser` local remains in scope until `convert()` returns. For an ~1.6 GB-decompressed
+net: ≈ 1.6 (B) + 3 × 1.6 (W) + 0.8 (FP16) ≈ **5.6 GB**, matching the measured ~5 GB.
+
+**W1 (engine `modelDesc`) is resident across both phases.** It is loaded in
+`NeuralNet::loadModelFile` *before* conversion (`metalbackend.cpp:369-389`). The CoreML/ANE
+inference path reads only scalar dims from it (`metalbackend.cpp:472-478`); only the
+MPSGraph/GPU path consumes its weight arrays (`modelDescToSwift`, `metalbackend.cpp:347`).
+On iOS (always ANE) W1's weights are dead weight.
+
+## Strategy: five independent, individually-measurable levers
+
+Applied in order; stop when the budget is met. **A5 is conditional** — implement only if
+on-device measurement after A1–A4 still does not fit.
+
+### A1 — Kill the redundant copies (convert phase) — low risk, big win
+
+- **`WeightEntry` becomes a non-owning view** (`Operations.hpp`):
+  ```cpp
+  struct WeightEntry {
+      std::string name;
+      const float* data = nullptr;   // points into the live KataGoModelDesc
+      size_t count = 0;
+      std::vector<int64_t> shape;
+      uint64_t blob_offset = 0;
+  };
+  ```
+  `KataGoOps::registerWeight` stores `{name, vec.data(), vec.size(), shape}` instead of
+  copying. Removes copy #2. `model` must stay alive through serialize — it already does
+  (a `convert()` local; MILBuilder holds it by `const&`).
+- **Drop `weights_copy`** (`Converter.cpp:56-57`): pass `builder.getWeights()` straight to
+  the serializer. Removes copy #3. `WeightSerializer::serialize` takes
+  `const std::vector<WeightEntry>&`; since views are const, move `blob_offset` tracking to
+  a returned/parallel offsets structure rather than mutating entries in place.
+- **Per-tensor FP16 to blob** (`WeightSerializer.cpp:11-36`): already loops per-entry with
+  one `fp16_data` temp; keep it, just read from `entry.data`/`entry.count`. No full-model
+  FP16 copy ever exists.
+
+After A1, the convert-phase live set is exactly **one** `model` + one per-layer FP16 temp
+(plus B until A2 lands).
+
+### A2 — Streaming gzip parse (convert phase)
+
+Replace the full-file `m_buffer` + `m_pos` indexing in `KataGoParser` with a streaming
+reader over `gzFile`:
+
+- A `GzStreamReader` holding the `gzFile`, a modest refill buffer (~1 MB), and primitives:
+  `skipWhitespace`, `readToken` (text), `readBinaryBlock(dst, nbytes)` (bulk `gzread`
+  straight into the destination FP32 vector).
+- **Format detection without a global scan:** today `parse()` does `std::search` over the
+  whole buffer for the `@BIN@` marker (`KataGoParser.cpp:94`). Replace with inline
+  detection at the first `readFloats` binary block (the marker immediately precedes every
+  binary float block); assert consistency thereafter. Both text and binary paths preserved.
+- `readFloats` binary path: consume the `@BIN@` marker from the stream, then
+  `readBinaryBlock` directly into the result vector — no whole-file buffer.
+
+Net effect: the decompressed file (B) is never materialized; only ~1 MB refill buffer plus
+the growing `model` exist during parse. Convert peak → ~1× weights.
+
+**A2 is the highest correctness risk** (byte-level parser). Gated by the golden-output test
+(below).
+
+### A3 — Free engine W1 weights in ANE mode (both phases) — bonus steady-state win
+
+In `convertAndCreateCoreMLOnlyHandle` (`metalbackend.cpp:451-511`), the scalar dims are
+already read from `modelDesc` *before* the conversion bridge call:
+
+1. Read scalar dims as today.
+2. **Free `modelDesc`'s weight arrays** via a new `ModelDesc::releaseWeights()` that clears
+   the large `std::vector`s but keeps scalars/dims — gated strictly to the ANE path.
+3. Then run conversion + handle creation.
+
+Removes W1 from **both** the convert and compile phases, and drops ~1.6 GB of steady-state
+RSS for the whole iOS session.
+
+**Safety:** must be a no-op in any GPU/MPSGraph configuration (macOS), where
+`modelDescToSwift` copies those arrays. Guard: release only when the model is used
+exclusively for ANE (no MPSGraph handle created from this `LoadedModel`). Exact guard
+mechanism is a planning detail with that hard constraint; macOS GPU path stays unchanged.
+
+### A4 — Increased-memory-limit entitlement (compile phase ceiling)
+
+Add to `ios/KataGo iOS/KataGo iOS/KataGo iOS.entitlements`:
+```xml
+<key>com.apple.developer.kernel.increased-memory-limit</key>
+<true/>
+<key>com.apple.developer.kernel.extended-virtual-addressing</key>
+<true/>
+```
+Raises the per-app jetsam ceiling on supported devices (meaningful bump even on the 4 GB
+iPad mini 6). Existing iCloud/APS entitlements untouched. Unreleased app → enabling the
+capability is low-friction.
+
+### A5 — (Conditional, deepest) Full layer-streaming convert
+
+Restructure so weights stream parse → FP16 → blob → free per layer, never holding the full
+`model` resident: build the MIL program structure from metadata (names/shapes/offset
+placeholders) while streaming weight bytes to the on-disk blob as each layer is parsed.
+Convert peak → ~one layer.
+
+**Trigger:** only if on-device peak after A1–A4 still exceeds the device budget. Tighten the
+Mac test budget accordingly when implemented.
+
+## Verification
+
+### Mac-side peak test (verification spine) — new `cpp/external/katagocoreml/test/`
+
+- New CMake `add_executable` + `add_test` target, host-only (not in the app), runnable via
+  `ctest` on macOS.
+- Runs `KataGoConverter::convert`, samples peak RSS via `getrusage(RUSAGE_SELF).ru_maxrss`
+  (bytes on macOS).
+- **Ratio-based budget**, model-size-independent: assert
+  `peak_RSS < decompressed_size × R` (R ≈ 1.5). **Fails on today's ~3–4× duplication**,
+  passes after A1/A2. Written first (TDD): watch it fail, implement until green.
+- Fixture: a small bundled/available test net for the always-on CI assertion. Developer
+  runs the same test locally against the real b40c768 to confirm the absolute peak on a
+  representative net.
+
+### Golden-output equivalence test (guards the A2 parser rewrite)
+
+- Convert a small net; assert the produced **weight blob is byte-identical** to a committed
+  golden hash (and/or identical model spec). Exercises both the binary `@BIN@` and text
+  paths.
+
+### Existing coverage
+
+- Engine/inference tests must still load the compiled `.mlmodelc` and produce sane outputs.
+- All three platforms (iOS / macOS / visionOS) must still build (per CLAUDE.md). The Mac
+  test target is host-only and not part of the app.
+
+## Error handling & fallbacks
+
+- Streaming reader throws on truncated/corrupt gzip; `convert_to_temp` still returns
+  `nullptr` on exception — no change to error reporting.
+- The existing crash sentinel (`pendingLoadModelTitle`, `ModelRunnerView.swift`) +
+  "may not have enough free memory" recovery banner (`ModelPickerView`) remain as the
+  last-resort safety net; not removed.
+- Precision unchanged (FP16 on ANE); golden test confirms identical weights.
+- A3 release is a no-op in GPU/MPSGraph configs; macOS GPU build + inference must still pass.
+
+## Expected outcome
+
+A1 + A2 roughly quarter the convert peak (≈1.6 GB → ~1× weights, no B). A3 removes ~1.6 GB
+of W1 from both phases. A4 raises the compile-phase ceiling. The bet: A1–A4 hit the 4 GB
+target without needing A5. If not, A5 brings the convert peak to ~one layer.
+
+## Affected files (anticipated)
+
+- `cpp/external/katagocoreml/src/builder/Operations.hpp` (`WeightEntry`, `registerWeight`)
+- `cpp/external/katagocoreml/src/builder/Operations.cpp`
+- `cpp/external/katagocoreml/src/serializer/WeightSerializer.{hpp,cpp}`
+- `cpp/external/katagocoreml/src/Converter.cpp`
+- `cpp/external/katagocoreml/src/parser/KataGoParser.{hpp,cpp}` (streaming reader, A2)
+- `cpp/external/katagocoreml/CMakeLists.txt` + new `cpp/external/katagocoreml/test/`
+- `cpp/neuralnet/desc.h` / `desc.cpp` (`ModelDesc::releaseWeights`, A3)
+- `cpp/neuralnet/metalbackend.cpp` (call `releaseWeights` in ANE path, A3)
+- `ios/KataGo iOS/KataGo iOS/KataGo iOS.entitlements` (A4)
+
+## Out of scope
+
+- Hosting pre-converted models / changing the distribution model.
+- Pointing the Official entry at a smaller net.
+- The `requireExactNNLen`/`requireMaxBoardSize` MPS experiment (separate future work).

--- a/docs/superpowers/specs/2026-05-30-reduce-conversion-peak-memory-design.md
+++ b/docs/superpowers/specs/2026-05-30-reduce-conversion-peak-memory-design.md
@@ -164,15 +164,53 @@ Mac test budget accordingly when implemented.
 - **Ratio-based budget**, model-size-independent: assert
   `peak_RSS < decompressed_size × R` (R ≈ 1.5). **Fails on today's ~3–4× duplication**,
   passes after A1/A2. Written first (TDD): watch it fail, implement until green.
-- Fixture: a small bundled/available test net for the always-on CI assertion. Developer
-  runs the same test locally against the real b40c768 to confirm the absolute peak on a
-  representative net.
+- Fixture: a committed `cpp/tests/models/` net for the always-on CI assertion (e.g.
+  `g170e-b10c128-…bin.gz`, the largest committed binary net, to best stress the ratio).
+  Developer runs the same test locally against the real b40c768 to confirm the absolute
+  peak on a representative net.
 
-### Golden-output equivalence test (guards the A2 parser rewrite)
+### Golden-output equivalence (guards the A1/A2 refactor) — expanded coverage
 
-- Convert a small net; assert the produced **weight blob is byte-identical** to a committed
-  golden hash (and/or identical model spec). Exercises both the binary `@BIN@` and text
-  paths.
+The refactor must produce **byte-identical** output to the pre-refactor converter. Byte
+identity of the weight blob + model spec strictly implies identical inference, so no
+separate numeric/inference comparison is needed for the converter (engine inference tests
+already cover end-to-end).
+
+**Fixtures (already committed under `cpp/tests/models/`):**
+
+- `g170-b6c96-s175395328-d26788732.bin.gz` (binary `@BIN@`) **and**
+  `g170-b6c96-s175395328-d26788732.txt.gz` (text) — the *same* net in both formats.
+- `g170e-b10c128-s1141046784-d204142634.bin.gz` (binary, larger).
+- `g103-b6c96-…txt.gz`, `grun2-b6c96-…txt.gz`, `grun50-b6c96-…txt.gz`,
+  `run4-…b6c96.txt.gz` (older model versions, text) — exercise different version branches.
+
+**Test types:**
+
+1. **Characterization goldens (matrix).** For each committed fixture, across
+   {FP16, FP32} × {19×19, 9×9} × {`optimize_identity_mask` on, off}, assert the refactored
+   converter reproduces a committed golden — **SHA-256 of the weight blob** and **SHA-256
+   of `model.mlmodel`** — generated from the pre-refactor converter at the start of
+   implementation (goldens frozen as step 1, then the refactor must keep them green). The
+   matrix exercises both parser paths, both precisions, the mask-constant/board-size paths,
+   and the `optimize_identity_mask` branch.
+2. **Cross-format equivalence.** Convert `g170-b6c96` from `.bin.gz` (streaming binary path)
+   and from `.txt.gz` (text path); assert **identical weight blob**. Pits the rewritten
+   streaming binary parser directly against the text parser — the core A2 risk — without
+   relying on a frozen golden.
+3. **Determinism.** Convert the same input twice → byte-identical output.
+
+**Equivalence granularity:** weight blob bytes byte-identical (SHA-256); `model.mlmodel`
+protobuf byte-identical (SHA-256), falling back to structural protobuf equality only if
+serialization ordering proves unstable across runs.
+
+**Named coverage gap (no silent gaps).** The committed CI fixtures are old (≈ v8–10,
+ordinary + global-pooling blocks). They do **not** exercise **nested-bottleneck blocks**,
+the **SGF metadata encoder**, or **model versions ≥ 15** — precisely the code paths the
+target b40c768**nbt** uses. Those are covered by a **developer-run (not CI) golden** that
+compares the refactored converter against a pre-refactor baseline on the real b40c768
+(and/or a smaller modern nbt net), committing only the golden hashes. Closing this gap in
+CI requires adding a small modern-architecture fixture (tracked as follow-up); until then
+the developer-run golden is the gate for the nbt/metadata/v16 paths.
 
 ### Existing coverage
 
@@ -204,6 +242,9 @@ target without needing A5. If not, A5 brings the convert peak to ~one layer.
 - `cpp/external/katagocoreml/src/Converter.cpp`
 - `cpp/external/katagocoreml/src/parser/KataGoParser.{hpp,cpp}` (streaming reader, A2)
 - `cpp/external/katagocoreml/CMakeLists.txt` + new `cpp/external/katagocoreml/test/`
+  (peak test + golden matrix + cross-format + determinism; reuses `cpp/tests/models/`
+  fixtures; committed golden hashes). Follow-up: add a small modern-architecture
+  (nested-bottleneck / v15+ / SGF-metadata) fixture to close the named CI coverage gap.
 - `cpp/neuralnet/desc.h` / `desc.cpp` (`ModelDesc::releaseWeights`, A3)
 - `cpp/neuralnet/metalbackend.cpp` (call `releaseWeights` in ANE path, A3)
 - `ios/KataGo iOS/KataGo iOS/KataGo iOS.entitlements` (A4)

--- a/ios/KataGo iOS/KataGo iOS/KataGo iOS.entitlements
+++ b/ios/KataGo iOS/KataGo iOS/KataGo iOS.entitlements
@@ -14,5 +14,9 @@
 	<array>
 		<string>CloudKit</string>
 	</array>
+	<key>com.apple.developer.kernel.increased-memory-limit</key>
+	<true/>
+	<key>com.apple.developer.kernel.extended-virtual-addressing</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
Cuts the one-time on-device KataGo→CoreML conversion peak memory so the 40-block **b40c768nbt** Official network loads without an OOM/jetsam kill on a 4 GB device. **Confirmed working on iPad mini 6** (the tightest budget, which previously crashed).

Four independent levers (output stays byte-identical — golden hashes unchanged throughout):
- **A1** — weight tensors become non-owning views into the parsed model; drops 2 of 3 resident FP32 weight copies (the lone transpose temporary uses an owned buffer).
- **A2** — parser streams the gzip on demand; the full decompressed file buffer is never resident.
- **A3** — frees the engine's ANE-dead `ModelDesc` weights after reading scalar dims (removes them from both the convert and compile phases, plus ~1.6 GB steady-state RSS on iOS).
- **A4** — `increased-memory-limit` + `extended-virtual-addressing` entitlements.

Supporting changes:
- New `./katago runcoremlconverttests` suite (METAL build only): smoke, **cross-format** (binary-stream vs text equivalence, 8 combos), determinism, **golden** (pins `weight.bin` + `model.mlmodel` hashes), and a peak-RSS ratio gate (strict on `KATAGO_COREML_PEAK_MODEL`).
- Deterministic protobuf serialization (`SetSerializationDeterministic(true)`) so `model.mlmodel` is byte-stable.
- Build-gate fix so the Xcode app links without the converter-test symbols.

## Test plan
- [x] Mac: `./katago runcoremlconverttests` (goldens) + `./katago runtests` pass
- [x] iOS Simulator + macOS app builds succeed (visionOS sim runtime not installed locally)
- [x] On-device: **iPad mini 6 (4 GB) loads b40c768 without OOM**
- [ ] iPhone 17 reconfirmation (optional)
- [ ] Strict peak gate on the real net: `KATAGO_COREML_PEAK_MODEL=<b40c768>.bin.gz ./katago runcoremlconverttests` (expect ratio < 1.5×)

## Notes
- Does not touch `MLModel.compileModel`'s own transient peak (Swift/OS side); **A5** (full layer-streaming convert) was designed as a fallback but proved unnecessary.
- A3 assumes ANE and GPU/MPSGraph are never mixed for one `LoadedModel` (iOS = ANE-only, macOS = GPU-only).
- Spec: `docs/superpowers/specs/2026-05-30-reduce-conversion-peak-memory-design.md`; plan: `docs/superpowers/plans/2026-05-30-reduce-conversion-peak-memory.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)