### PR TITLE
Fix Windows CI: stop pinning CMake to the VS 2022 generator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
     - name: Configure CMake
       working-directory: cpp
       run: |
-        cmake . -G "Visual Studio 17 2022" -A x64 `
+        cmake . -A x64 `
           -DUSE_BACKEND=OPENCL `
           -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 


### PR DESCRIPTION
## Summary

The `build-windows` CI job started failing at the CMake configure step:

```
CMake Error at CMakeLists.txt:34 (project):
  Generator "Visual Studio 17 2022" could not find any instance of Visual Studio.
```

GitHub migrated the `windows-latest` runner image to Windows Server 2025 with **Visual Studio 2026 only** (rolled out June 8–15, 2026, see [actions/runner-images#14017](https://github.com/actions/runner-images/issues/14017)), so the hard-coded `-G "Visual Studio 17 2022"` generator no longer resolves.

## Fix

Drop the explicit generator from the Configure CMake step, keeping `-A x64`. CMake auto-detects the newest installed Visual Studio (VS 2026 on the current image), and the job will survive future VS bumps on the runner image without further edits. All other steps (`--config Release` build, `Release/` paths, DLL copy, tests) are generator-version-agnostic.

## Verification

`workflow_dispatch` run on this branch: [run 27383148471](https://github.com/ChinChangYang/KataGo/actions/runs/27383148471) — all 4 jobs passed, including `build-windows` (configure under VS 2026, build, and `katago.exe runtests` all green).

https://claude.ai/code/session_018eaSTE1PhvV7SsiNyJrq76

---
_Generated by [Claude Code](https://claude.ai/code/session_018eaSTE1PhvV7SsiNyJrq76)_