### PR TITLE
Scale node table shard count with search threads to cut match/selfplay memory peak

### DIFF
--- a/cpp/configs/match_example.cfg
+++ b/cpp/configs/match_example.cfg
@@ -240,5 +240,8 @@ chosenMoveTemperature = 0.20
 # rootPolicyOptimism = 0.2
 # policyOptimism = 1.0
 
+# Number of shards (as a power of two) for the per-search transposition node table. Each search allocates memory
+# proportional to this, so with many concurrent game threads it dominates the memory peak. When left unspecified it
+# now defaults based on numSearchThreads (capped at 16) rather than always 16, which greatly reduces memory in matches.
 # nodeTableShardsPowerOfTwo = 16
 # numVirtualLossesPerThread = 1

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -711,7 +711,19 @@ vector<SearchParams> Setup::loadParams(
 
     if(cfg.contains("nodeTableShardsPowerOfTwo"+idxStr)) params.nodeTableShardsPowerOfTwo = cfg.getInt("nodeTableShardsPowerOfTwo"+idxStr, 8, 24);
     else if(cfg.contains("nodeTableShardsPowerOfTwo"))   params.nodeTableShardsPowerOfTwo = cfg.getInt("nodeTableShardsPowerOfTwo",        8, 24);
-    else                                                 params.nodeTableShardsPowerOfTwo = 16;
+    else {
+      //Default the node table shard count based on the number of search threads instead of always using a large
+      //fixed value. Every Search allocates a node table whose memory footprint is proportional to the shard count
+      //(a pool of mutexes plus one std::map per shard - roughly 8MB of empty tables per Search at the old default of
+      //16). That fixed cost dominates the memory peak of match/selfplay, where each of potentially thousands of game
+      //threads holds its own Search (and, in match, possibly one per side). The shard count only needs to be large
+      //enough to keep lock contention low across the search threads, so scale it with numThreads (~128 shards per
+      //thread) while clamping to [8,16] to preserve the historical 65536-shard behavior for heavily-threaded searches.
+      int shardsPow = 8;
+      while(shardsPow < 16 && ((int64_t)1 << shardsPow) < (int64_t)params.numThreads * 128)
+        shardsPow += 1;
+      params.nodeTableShardsPowerOfTwo = shardsPow;
+    }
     if(cfg.contains("numVirtualLossesPerThread"+idxStr)) params.numVirtualLossesPerThread = cfg.getDouble("numVirtualLossesPerThread"+idxStr, 0.01, 1000.0);
     else if(cfg.contains("numVirtualLossesPerThread"))   params.numVirtualLossesPerThread = cfg.getDouble("numVirtualLossesPerThread",        0.01, 1000.0);
     else                                                 params.numVirtualLossesPerThread = 1.0;


### PR DESCRIPTION
Every Search allocated a SearchNodeTable with a fixed 2^16 = 65536 shards by
default, regardless of how small the search actually is. Each shard costs a
mutex plus a std::map, and Search keeps a second mutex pool of the same size,
so a single Search reserved ~8 MiB of empty tables before searching anything.

In the match and selfplay subcommands every game thread holds its own Search
(and in match, potentially one per side), so this fixed overhead is multiplied
by numGameThreads and dominates the peak memory footprint. With, e.g., 256 game
threads at one search thread each, that is ~2 GiB of empty hash tables.

The shard count only needs to be large enough to keep lock contention low
across the search threads of a single Search, which in match/selfplay is
typically one. Default nodeTableShardsPowerOfTwo based on numSearchThreads
(~128 shards per thread), clamped to [8, 16], so lightweight single-threaded
searches use 256 shards (~32 KiB) while heavily-threaded searches keep the
historical 65536-shard behavior. An explicit nodeTableShardsPowerOfTwo in the
config still overrides this.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UgRZ525h6fWmDfE6G9vin8