### PR TITLE
Allow negative utility factors for "misere" search

### DIFF
--- a/cpp/configs/gtp_human_misere_example.cfg
+++ b/cpp/configs/gtp_human_misere_example.cfg
@@ -1,0 +1,121 @@
+
+# EXPERIMENTAL example config: "misere" / 送頭 search for imitating VERY weak players.
+#
+# The human SL model's weakest faithfully-trained rank is 20k (profiles like preaz_30k do not exist).
+# To behave weaker than that, this config inverts the search objective so that BOTH players search for
+# the move that most LOSES, rather than wins. The idea (for sub-20k play): a very weak opponent plays
+# moves that are often worse than random, i.e. effectively also "trying to lose", so a symmetric
+# both-sides-want-to-lose ("misere") search is a closer model of that world than a normal win-seeking
+# search. Temperature is then used to calibrate HOW MUCH we blunder (送頭度) toward a target strength.
+#
+# This requires the negative-utility-factor support (lower bound -1.0 on the *UtilityFactor params).
+#
+# Run like the other human examples, e.g.:
+# ./katago gtp -config gtp_human_misere_example.cfg -model your_normal_model.bin.gz -human-model b18c384nbt-humanv0.bin.gz
+# Get the human model at https://github.com/lightvector/KataGo/releases/tag/v1.15.0
+#
+# IMPORTANT CAVEATS:
+# - The value/score net is trained as a WIN-seeking evaluator. It is NOT reliable for deep "how to lose"
+#   lines (out-of-distribution). So we keep the search SHALLOW and lean on the (more local, more robust)
+#   SCORE signal via a negative staticScoreUtilityFactor as the PRIMARY driver of 送頭.
+# - Endgame can degenerate (pass wars / eye-filling), since terminal misere positions are pure OOD.
+# - Final blunder rate MUST be tuned by playing test games and adjusting temperature + score factor.
+
+logDir = gtp_logs
+logAllGTPCommunication = true
+logSearchInfo = true
+logSearchInfoForChosenMove = false
+logToStderr = false
+
+rules = japanese
+
+# A weak, throwing bot will keep fighting; only resign when truly hopeless.
+allowResignation = true
+resignThreshold = -0.99
+resignConsecTurns = 20
+resignMinScoreDifference = 40
+resignMinMovesPerBoardArea = 0.4
+
+# Keep the search SHALLOW. Deep misere search backs up unreliable OOD values; a few visits is enough
+# to find "which human-plausible move loses the most right now" and to keep pass/resign sane.
+maxVisits = 16
+numSearchThreads = 1
+lagBuffer = 1.0
+
+delayMoveScale = 2.0
+delayMoveMax = 10.0
+
+# ===========================================================================
+# HUMAN SL PARAMETERS - anchor the STYLE of blunders to the weakest human rank
+# ===========================================================================
+
+# Anchor blunder *style* to the weakest faithfully-trained rank. This keeps the bad moves human-shaped
+# (pushing into contact, thin/heavy shapes) rather than engine-weird (self-atari, filling own eyes).
+humanSLProfile = preaz_20k
+
+humanSLChosenMoveProp = 1.0
+humanSLChosenMoveIgnorePass = true
+
+# Disabled (large number). PiklLambda shifts selection by utility differences; with inverted utility its
+# meaning flips, so we leave it off and let temperature do the calibration instead.
+humanSLChosenMovePiklLambda = 100000000
+
+# Restrict the search to human-plausible moves (weightful, so they DO affect the value), so that the
+# "most-losing" move we pick is one a weak human might actually consider, not an arbitrary engine blunder.
+humanSLRootExploreProbWeightless = 0.0
+humanSLRootExploreProbWeightful = 0.5
+humanSLPlaExploreProbWeightless = 0.0
+humanSLPlaExploreProbWeightful = 0.8
+humanSLOppExploreProbWeightless = 0.0
+humanSLOppExploreProbWeightful = 0.8
+
+humanSLCpuctExploration = 0.50
+humanSLCpuctPermanent = 1.0
+
+# ===========================================================================
+# INVERTED ("misere" / 送頭) UTILITY - the core of this config
+# ===========================================================================
+
+# Negative factors flip the objective: every node now MINIMIZES its own normal utility, i.e. both players
+# search for the most-losing move. Score is the PRIMARY driver (more robust than deep win/loss), so it
+# gets the larger magnitude and actively wants to lose points = 送頭. winLoss is kept small/negative.
+# (These require the relaxed lower bound of -1.0 in setup.cpp.)
+winLossUtilityFactor = -0.2
+staticScoreUtilityFactor = -0.6
+dynamicScoreUtilityFactor = 0.0
+
+# ===========================================================================
+# TEMPERATURE - calibrate the DEGREE of 送頭 to the target strength
+# ===========================================================================
+
+# In misere search, visits concentrate on the most-losing moves.
+#   temperature -> 0 : always play the most-losing move  => maximal 送頭 (weakest possible)
+#   higher temperature: mix in less-losing moves          => less 送頭 (relatively stronger)
+# A 30k-ish player does NOT throw maximally, so use a moderate temperature and TUNE BY PLAYTESTING.
+chosenMoveTemperatureEarly = 0.80
+chosenMoveTemperature = 0.70
+chosenMoveTemperatureHalflife = 80
+chosenMoveTemperatureOnlyBelowProb = 0.5   # let temperature also act on higher-prob moves, not just rare ones
+chosenMoveSubtract = 0
+chosenMovePrune = 0
+
+nnCacheSizePowerOfTwo = 17
+nnMutexPoolSizePowerOfTwo = 14
+
+# ===========================================================================
+# PARAMETERS REQUIRED FOR THIS MODE TO WORK CORRECTLY
+# ===========================================================================
+
+ignorePreRootHistory = false
+analysisIgnorePreRootHistory = false
+rootNumSymmetriesToSample = 2
+useLcbForSelection = false
+
+# REQUIRED: with a negative winLossUtilityFactor the uncertainty term can go negative and produce NaN
+# (it takes a sqrt). Uncertainty must be OFF in this mode.
+useUncertainty = false
+
+# Off for the same reasons as the other human-SL configs: these add strength but interfere with the
+# weightful human-policy biasing and value manipulation we are doing here.
+subtreeValueBiasFactor = 0.0
+useNoisePruning = false

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -448,14 +448,19 @@ vector<SearchParams> Setup::loadParams(
     else if(cfg.contains("minPlayoutsPerThread"))   params.minPlayoutsPerThread = cfg.getDouble("minPlayoutsPerThread",        0.0, 1.0e20);
     else                                            params.minPlayoutsPerThread = (setupFor == SETUP_FOR_ANALYSIS || setupFor == SETUP_FOR_GTP) ? 8.0 : 0.0;
 
-    if(cfg.contains("winLossUtilityFactor"+idxStr)) params.winLossUtilityFactor = cfg.getDouble("winLossUtilityFactor"+idxStr, 0.0, 1.0);
-    else if(cfg.contains("winLossUtilityFactor"))   params.winLossUtilityFactor = cfg.getDouble("winLossUtilityFactor",        0.0, 1.0);
+    // Lower bound is -1.0 rather than 0.0 to allow inverting the utility ("misere"/送頭 search), where
+    // both players search for the move that most loses. Combined with temperature this can calibrate a bot
+    // to play at a degree of blundering matching very weak (e.g. sub-20k) opponents. Use negative score
+    // factors as the primary driver; the value net is a win-seeking evaluator and is unreliable for deep
+    // losing lines, so keep search shallow and lean on the (more local) score signal.
+    if(cfg.contains("winLossUtilityFactor"+idxStr)) params.winLossUtilityFactor = cfg.getDouble("winLossUtilityFactor"+idxStr, -1.0, 1.0);
+    else if(cfg.contains("winLossUtilityFactor"))   params.winLossUtilityFactor = cfg.getDouble("winLossUtilityFactor",        -1.0, 1.0);
     else                                            params.winLossUtilityFactor = 1.0;
-    if(cfg.contains("staticScoreUtilityFactor"+idxStr)) params.staticScoreUtilityFactor = cfg.getDouble("staticScoreUtilityFactor"+idxStr, 0.0, 1.0);
-    else if(cfg.contains("staticScoreUtilityFactor"))   params.staticScoreUtilityFactor = cfg.getDouble("staticScoreUtilityFactor",        0.0, 1.0);
+    if(cfg.contains("staticScoreUtilityFactor"+idxStr)) params.staticScoreUtilityFactor = cfg.getDouble("staticScoreUtilityFactor"+idxStr, -1.0, 1.0);
+    else if(cfg.contains("staticScoreUtilityFactor"))   params.staticScoreUtilityFactor = cfg.getDouble("staticScoreUtilityFactor",        -1.0, 1.0);
     else                                                params.staticScoreUtilityFactor = 0.1;
-    if(cfg.contains("dynamicScoreUtilityFactor"+idxStr)) params.dynamicScoreUtilityFactor = cfg.getDouble("dynamicScoreUtilityFactor"+idxStr, 0.0, 1.0);
-    else if(cfg.contains("dynamicScoreUtilityFactor"))   params.dynamicScoreUtilityFactor = cfg.getDouble("dynamicScoreUtilityFactor",        0.0, 1.0);
+    if(cfg.contains("dynamicScoreUtilityFactor"+idxStr)) params.dynamicScoreUtilityFactor = cfg.getDouble("dynamicScoreUtilityFactor"+idxStr, -1.0, 1.0);
+    else if(cfg.contains("dynamicScoreUtilityFactor"))   params.dynamicScoreUtilityFactor = cfg.getDouble("dynamicScoreUtilityFactor",        -1.0, 1.0);
     else                                                 params.dynamicScoreUtilityFactor = 0.3;
     if(cfg.contains("noResultUtilityForWhite"+idxStr)) params.noResultUtilityForWhite = cfg.getDouble("noResultUtilityForWhite"+idxStr, -1.0, 1.0);
     else if(cfg.contains("noResultUtilityForWhite"))   params.noResultUtilityForWhite = cfg.getDouble("noResultUtilityForWhite",        -1.0, 1.0);


### PR DESCRIPTION
Relax the lower bound of winLossUtilityFactor, staticScoreUtilityFactor,
and dynamicScoreUtilityFactor from 0.0 to -1.0 in config parsing. Negative
factors invert the search objective so both players search for the
most-losing move, which models the sub-20k regime (where weak opponents
play worse than random) better than a normal win-seeking search. Strength
is then calibrated via temperature.

Add gtp_human_misere_example.cfg demonstrating the setup, with the
necessary guardrails (useUncertainty=false to avoid a NaN from the
negative-factor uncertainty term, shallow search since the value net is
unreliable for deep losing lines, and human-SL exploration to keep
blunders human-shaped).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0124xb2Xkir35BQHpuxthSPS